### PR TITLE
Replace tag with tagPublic in TestPublic to include full tagType

### DIFF
--- a/backend/app/models/test.py
+++ b/backend/app/models/test.py
@@ -251,7 +251,7 @@ class TestPublic(TestBase):
     created_date: datetime
     modified_date: datetime
     is_deleted: bool
-    tags: list["Tag"]
+    tags: list["TagPublic"]
     question_revisions: list["QuestionRevision"]
     states: list["State"]
     districts: list["District"]

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -650,7 +650,10 @@ def test_get_tests(
     assert any(item["created_by_id"] == test.created_by_id for item in data)
 
     assert any(
-        len(item["tags"]) == 1 and item["tags"][0]["id"] == tag_a.id for item in data
+        len(item["tags"]) == 1
+        and item["tags"][0]["id"] == tag_a.id
+        and item["tags"][0].get("tag_type", {}).get("name") == tag_type.name
+        for item in data
     )
     assert any(
         len(item["states"]) == 1 and item["states"][0]["id"] == state_a.id


### PR DESCRIPTION
## Summary

Currently, TestPublic returns tag objects containing only tag_type ID.  
This change replaces tag with tagPublic so that the full tagType object is included.  
This ensures the frontend can access tagType name  directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated test API responses to return the public tag representation for each tag, ensuring correct and consistent tag type metadata.
- Tests
  - Strengthened validations to ensure each returned tag matches the expected ID and its tag type aligns with the associated test’s tag_type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->