### PR TITLE
add total_questions field to Result API response

### DIFF
--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -1004,11 +1004,13 @@ def get_test_result(
                     incorrect += 1
                     if marking_scheme:
                         marks_obtained += marking_scheme["wrong"]
+    total_questions = len(candidate_test.question_revision_ids)
     return Result(
         correct_answer=correct,
         incorrect_answer=incorrect,
         mandatory_not_attempted=mandatory_not_attempted,
         optional_not_attempted=optional_not_attempted,
+        total_questions=total_questions,
         marks_obtained=marks_obtained if marking_scheme else None,
         marks_maximum=marks_maximum if marking_scheme else None,
     )

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -243,6 +243,7 @@ class Result(SQLModel):
     incorrect_answer: int
     mandatory_not_attempted: int
     optional_not_attempted: int
+    total_questions: int
     marks_obtained: float | None
     marks_maximum: float | None
 

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -1841,9 +1841,9 @@ def test_get_test_result(
         description=random_lower_string(),
         time_limit=60,
         marks=100,
-        start_instructions="Test instructions",
+        start_instructions=random_lower_string(),
         link=random_lower_string(),
-        created_by_id=user.id,  # Assuming user ID 1 exists
+        created_by_id=user.id,
         is_active=True,
         is_deleted=False,
     )
@@ -1930,7 +1930,7 @@ def test_get_test_result(
     db.refresh(candidate_test_answer)
     candidate_test_answer = CandidateTestAnswer(
         candidate_test_id=candidate_test_id,
-        question_revision_id=questions[1].id,  # Assuming question revision ID 1 exists
+        question_revision_id=questions[1].id,
         response=2,
         visited=True,
         time_spent=30,
@@ -1974,6 +1974,7 @@ def test_get_test_result(
     assert data["incorrect_answer"] == 2
     assert data["mandatory_not_attempted"] == 0
     assert data["optional_not_attempted"] == 0
+    assert data["total_questions"] == 4
     assert data["marks_obtained"] == 2
     assert data["marks_maximum"] == 4
 
@@ -3099,6 +3100,7 @@ def test_result_with_no_answers(
     assert data["incorrect_answer"] == 0
     assert data["mandatory_not_attempted"] == 1
     assert data["optional_not_attempted"] == 0
+    assert data["total_questions"] == 2
     assert data["marks_obtained"] == 1
     assert data["marks_maximum"] == 2
 
@@ -3210,6 +3212,7 @@ def test_result_with_mixed_answers_test_level_marking(
     assert data["incorrect_answer"] == 1
     assert data["mandatory_not_attempted"] == 1
     assert data["optional_not_attempted"] == 0
+    assert data["total_questions"] == 3
     assert data["marks_obtained"] == 3  # 5 - 2 + 0
     assert data["marks_maximum"] == 15  # 3 questions × 5 each
 


### PR DESCRIPTION
Fixes issue: #298 
## Summary
add total_questions field to Result API response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test results now include the total question count for each test across all candidate result endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->