### PR TITLE
Rename "Training Tags" to "Tags"

### DIFF
--- a/backend/app/api/routes/question.py
+++ b/backend/app/api/routes/question.py
@@ -1266,9 +1266,9 @@ async def upload_questions_csv(
                 # Process tags if present
                 tag_ids = []
                 tagtype_error = False
-                if "Training Tags" in row and row["Training Tags"].strip():
+                if "Tags" in row and row["Tags"].strip():
                     tag_entries = [
-                        t.strip() for t in row["Training Tags"].split("|") if t.strip()
+                        t.strip() for t in row["Tags"].split("|") if t.strip()
                     ]
 
                     for tag_entry in tag_entries:

--- a/backend/app/tests/api/routes/test_question.py
+++ b/backend/app/tests/api/routes/test_question.py
@@ -1975,7 +1975,7 @@ def test_bulk_upload_questions(
 
     # Create a CSV file with test data - add an empty row to test skipping
     # Also includes duplicate tags to test tag cache
-    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,State
+    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,State
 What is 2+2?,4,3,5,6,A,Test Tag Type:Math,Punjab
 What is the capital of France?,Paris,London,Berlin,Madrid,A,Test Tag Type:Geography,Punjab
 What is H2O?,Water,Gold,Silver,Oxygen,A,Test Tag Type:Chemistry,Punjab
@@ -2019,7 +2019,9 @@ What are prime numbers?,Numbers divisible only by 1 and themselves,Even numbers,
         assert response.status_code in [400, 500]
 
         # Test with headers-only CSV (line 1045)
-        headers_only_csv = "Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,State\n"
+        headers_only_csv = (
+            "Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,State\n"
+        )
         with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as temp_file:
             temp_file.write(headers_only_csv.encode("utf-8"))
             headers_only_csv_path = temp_file.name
@@ -2108,7 +2110,7 @@ What are prime numbers?,Numbers divisible only by 1 and themselves,Even numbers,
                 assert any(loc["state_name"] == "Punjab" for loc in locations)
 
         # Test with non-existent tag type
-        csv_content_bad_tag = """Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,State
+        csv_content_bad_tag = """Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,State
 What is a prime number?,A number only divisible by 1 and itself,An even number,An odd number,A fractional number,A,NonExistentType:Math,Punjab
 """
         with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as temp_file:
@@ -2126,7 +2128,7 @@ What is a prime number?,A number only divisible by 1 and itself,An even number,A
         assert "Failed to create" in data["message"]
 
         # Test upload with non-existent state
-        csv_content_bad_state = """Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,State
+        csv_content_bad_state = """Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,State
 What is the highest mountain?,Everest,K2,Denali,Kilimanjaro,A,Test Tag Type:Geography,NonExistentState
 """
         with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as temp_file:
@@ -3365,7 +3367,7 @@ def test_bulk_upload_questions_response_format(
     db.add(tag_type)
     db.commit()
     db.refresh(tag_type)
-    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,State
+    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,State
 What is 4+4?,4,3,5,8,A,Response Model Type:Math,Punjab
 What is the capital of France?,Paris,London,Berlin,Madrid,A,Response Model Type:Geography,Punjab
 Water,Gold,Silver,Carbon,A,Response Model Type:Chemistry,Punjab
@@ -3499,7 +3501,7 @@ def test_bulk_upload_questions_without_tagtype(
     db.add(tag_type)
     db.commit()
     db.refresh(tag_type)
-    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,State
+    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,State
 What is 10+10?,20,10,30,40,A,Math,Punjab
 What is the color of the sky?,Blue,Green,Red,Yellow,A,Science,Punjab
 What is 5x5?,25,10,15,20,A,Subject:Multiplication,Punjab
@@ -3566,7 +3568,7 @@ def test_bulk_upload_questions_with_invalid_tagtype(
     db.add(punjab)
     db.commit()
     db.refresh(punjab)
-    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,State
+    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,State
     What is 10+10?,20,10,30,40,A,Math,Punjab
     What is the color of the sky?,Blue,Green,Red,Yellow,A,Science,Punjab
     What is 5x5?,25,10,15,20,A,InvalidTagType:Multiplication,Punjab
@@ -3955,7 +3957,7 @@ def test_bulk_upload_questions_with_duplicate(
     db.add(punjab)
     db.commit()
     db.refresh(punjab)
-    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,State
+    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,State
     What is 10+10?,20,10,30,40,A,Math,Punjab
      What is 10+10?,20,10,30,40,A,Math,Punjab
     What is PYTHON?,Programming Language,Snake,Car,Food,A,Bulk TagType:BulkTag,Punjab
@@ -4404,7 +4406,7 @@ def test_bulk_upload_questions_with_multiple_errors_report(
     db.add(punjab)
     db.commit()
     db.refresh(punjab)
-    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,State
+    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,State
 What is 10+10?,20,10,30,40,A,Math,Punjab
 What is the color of the sky?,Blue,Green,Red,Yellow,A,Science,Punjab
 What is 5x5?,25,10,15,20,A,InvalidTagType:Multiplication,Punjab
@@ -4625,7 +4627,7 @@ def test_bulk_upload_questions_without_state_column(
     db.add(punjab)
     db.commit()
     db.refresh(punjab)
-    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Training Tags,
+    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,Tags,
 What is the color of the sky?,Blue,Green,Red,Yellow,A,Science
 What is 5x5?,25,10,15,20,A,InvalidTagType:Multiplication
 What is the capital of India?,Delhi,Mumbai,Kolkata,Chennai,A,InvalidTagType:Geography
@@ -4671,7 +4673,7 @@ def test_bulk_upload_questions_with_extra_column(
     db.add(punjab)
     db.commit()
     db.refresh(punjab)
-    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,ABCD,Training Tags,State,ABCD
+    csv_content = """Questions,Option A,Option B,Option C,Option D,Correct Option,ABCD,Tags,State,ABCD
 What is 10+10?,20,10,30,40,A,ABCD,Math,Punjab
 What is the color of the sky?,Blue,Green,Red,Yellow,A,ABCD,Science,Punjab
 Which option is missing?,25,10,20,30,A,ABCD,Math,Punjab


### PR DESCRIPTION
fixes: #343 
Question Bulk Upload: Renaming 'Training Tags' Column to Tags


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * CSV bulk upload format updated: the "Tags" column header is now used instead of "Training Tags" for importing question data. Users must update their CSV files to reflect this header name change when performing bulk uploads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->