### PR TITLE
BigQuery Sync: Add new tables, schema changes and upgrade schema mode…

### DIFF
--- a/backend/app/services/data_sync.py
+++ b/backend/app/services/data_sync.py
@@ -30,10 +30,16 @@ from app.models import (
     User,
 )
 from app.models.candidate import CandidateTestProfile
-from app.models.form import Form, FormResponse
+from app.models.form import Form, FormField, FormResponse
 from app.models.provider import ProviderType
-from app.models.test import MarksLevelEnum, TestDistrict, TestQuestion, TestTag
-from app.models.user import UserState
+from app.models.test import (
+    MarksLevelEnum,
+    TestDistrict,
+    TestQuestion,
+    TestState,
+    TestTag,
+)
+from app.models.user import UserDistrict, UserState
 from app.services.datasync.base import SyncResult
 from app.services.datasync.bigquery import BigQueryService
 from app.services.google_slides import GoogleSlidesService
@@ -193,6 +199,63 @@ class DataSyncService:
 
         return results
 
+    def upgrade_organization_schemas(
+        self, organization_id: int
+    ) -> dict[str, dict[str, dict[str, list[str]]]]:
+        """Upgrade BigQuery schemas for an organization's providers.
+        Returns dict of provider_key -> {table_name -> {"added": [...], "relaxed": [...]}}.
+        """
+        org_providers = self.get_organization_providers(organization_id)
+        results: dict[str, dict[str, dict[str, list[str]]]] = {}
+
+        for org_provider in org_providers:
+            if org_provider.provider.provider_type != ProviderType.BIGQUERY:
+                continue
+            if org_provider.config_json is None:
+                continue
+
+            provider_key = f"org_{organization_id}_{org_provider.provider.name}"
+            try:
+                decrypted_config = provider_config_service.get_config_for_use(
+                    org_provider.config_json
+                )
+                bigquery_service = BigQueryService(organization_id, decrypted_config)
+                results[provider_key] = bigquery_service.upgrade_schemas()
+            except Exception as e:
+                logger.error(f"Schema upgrade failed for {provider_key}: {e}")
+                results[provider_key] = {"_error": {"errors": [str(e)]}}
+
+        return results
+
+    def upgrade_all_organizations_schemas(
+        self,
+    ) -> dict[int, dict[str, dict[str, dict[str, list[str]]]]]:
+        """Upgrade BigQuery schemas for all organizations.
+        Returns dict of org_id -> {provider_key -> {table_name -> {"added": [...], "relaxed": [...]}}}.
+        """
+        results: dict[int, dict[str, dict[str, dict[str, list[str]]]]] = {}
+
+        with Session(engine) as session:
+            organizations = session.exec(
+                select(Organization).where(
+                    Organization.is_active,
+                    ~Organization.is_deleted,  # type: ignore[arg-type]
+                )
+            ).all()
+
+            for org in organizations:
+                if org.id is None:
+                    continue
+                try:
+                    org_results = self.upgrade_organization_schemas(org.id)
+                    if org_results:
+                        results[org.id] = org_results
+                except Exception as e:
+                    logger.error(f"Schema upgrade failed for org {org.id}: {e}")
+                    results[org.id] = {"_error": {"_error": {"errors": [str(e)]}}}
+
+        return results
+
     def _get_table_specific_last_sync(
         self, organization_id: int, table_name: str
     ) -> datetime | None:
@@ -307,6 +370,12 @@ class DataSyncService:
             data["form_responses"] = self._extract_form_responses_data(
                 session, organization_id, incremental
             )
+            data["forms"] = self._extract_forms_data(
+                session, organization_id, incremental
+            )
+            data["form_fields"] = self._extract_form_fields_data(
+                session, organization_id, incremental
+            )
             data["states"] = self._extract_states_data(
                 session, organization_id, incremental
             )
@@ -341,6 +410,15 @@ class DataSyncService:
                 session, organization_id, incremental
             )
             data["user_states"] = self._extract_user_states_data(
+                session, organization_id, incremental
+            )
+            data["certificates"] = self._extract_certificates_data(
+                session, organization_id, incremental
+            )
+            data["test_states"] = self._extract_test_states_data(
+                session, organization_id, incremental
+            )
+            data["user_districts"] = self._extract_user_districts_data(
                 session, organization_id, incremental
             )
 
@@ -673,6 +751,43 @@ class DataSyncService:
         results = session.exec(statement).all()
         return [self._serialize_form_response(fr, org_id) for fr, org_id in results]
 
+    def _extract_forms_data(
+        self, session: Session, organization_id: int, incremental: bool
+    ) -> list[dict[str, Any]]:
+        statement = select(Form).where(Form.organization_id == organization_id)
+
+        if incremental:
+            table_last_sync = self._get_table_specific_last_sync(
+                organization_id, "forms"
+            )
+            if table_last_sync is not None:
+                statement = statement.where(Form.modified_date > table_last_sync)  # type: ignore[operator]
+
+        forms = session.exec(statement).all()
+        return [self._serialize_form(form) for form in forms]
+
+    def _extract_form_fields_data(
+        self, session: Session, organization_id: int, incremental: bool
+    ) -> list[dict[str, Any]]:
+        # Filter form_fields by organization through form.organization_id
+        statement = (
+            select(FormField)
+            .join(Form, FormField.form_id == Form.id)  # type: ignore[arg-type]
+            .where(Form.organization_id == organization_id)
+        )
+
+        if incremental:
+            table_last_sync = self._get_table_specific_last_sync(
+                organization_id, "form_fields"
+            )
+            if table_last_sync is not None:
+                statement = statement.where(
+                    FormField.modified_date > table_last_sync  # type: ignore[operator]
+                )
+
+        form_fields = session.exec(statement).all()
+        return [self._serialize_form_field(ff) for ff in form_fields]
+
     def _extract_test_questions_data(
         self, session: Session, organization_id: int, incremental: bool
     ) -> list[dict[str, Any]]:
@@ -761,6 +876,66 @@ class DataSyncService:
         user_states = session.exec(statement).all()
         return [self._serialize_user_state(us) for us in user_states]
 
+    def _extract_certificates_data(
+        self, session: Session, organization_id: int, incremental: bool
+    ) -> list[dict[str, Any]]:
+        statement = select(Certificate).where(
+            Certificate.organization_id == organization_id
+        )
+
+        if incremental:
+            table_last_sync = self._get_table_specific_last_sync(
+                organization_id, "certificates"
+            )
+            if table_last_sync is not None:
+                statement = statement.where(Certificate.modified_date > table_last_sync)  # type: ignore[operator]
+
+        certificates = session.exec(statement).all()
+        return [self._serialize_certificate(cert) for cert in certificates]
+
+    def _extract_test_states_data(
+        self, session: Session, organization_id: int, incremental: bool
+    ) -> list[dict[str, Any]]:
+        # Filter test_states through test.organization_id
+        statement = (
+            select(TestState, Test.organization_id)
+            .join(Test, TestState.test_id == Test.id)  # type: ignore[arg-type]
+            .where(Test.organization_id == organization_id)
+        )
+
+        if incremental:
+            table_last_sync = self._get_table_specific_last_sync(
+                organization_id, "test_states"
+            )
+            if table_last_sync is not None:
+                statement = statement.where(TestState.created_date > table_last_sync)  # type: ignore[operator]
+
+        results = session.exec(statement).all()
+        return [
+            self._serialize_test_state(test_state, org_id)
+            for test_state, org_id in results
+        ]
+
+    def _extract_user_districts_data(
+        self, session: Session, organization_id: int, incremental: bool
+    ) -> list[dict[str, Any]]:
+        # Filter user_districts through user -> organization
+        statement = (
+            select(UserDistrict)
+            .join(User, UserDistrict.user_id == User.id)  # type: ignore[arg-type]
+            .where(User.organization_id == organization_id)
+        )
+
+        if incremental:
+            table_last_sync = self._get_table_specific_last_sync(
+                organization_id, "user_districts"
+            )
+            if table_last_sync is not None:
+                statement = statement.where(UserDistrict.created_date > table_last_sync)  # type: ignore[operator]
+
+        user_districts = session.exec(statement).all()
+        return [self._serialize_user_district(ud) for ud in user_districts]
+
     def _serialize_user(self, user: User) -> dict[str, Any]:
         return {
             "id": user.id,
@@ -798,6 +973,7 @@ class DataSyncService:
             "marking_scheme": test.marking_scheme,
             "created_by_id": test.created_by_id,
             "organization_id": test.organization_id,
+            "form_id": test.form_id,
             "created_date": (
                 test.created_date.isoformat() if test.created_date else None
             ),
@@ -1069,6 +1245,49 @@ class DataSyncService:
             ),
         }
 
+    def _serialize_form(self, form: Form) -> dict[str, Any]:
+        return {
+            "id": form.id,
+            "name": form.name,
+            "description": form.description,
+            "is_active": form.is_active,
+            "organization_id": form.organization_id,
+            "created_by_id": form.created_by_id,
+            "created_date": (
+                form.created_date.isoformat() if form.created_date else None
+            ),
+            "modified_date": (
+                form.modified_date.isoformat() if form.modified_date else None
+            ),
+        }
+
+    def _serialize_form_field(self, form_field: FormField) -> dict[str, Any]:
+        return {
+            "id": form_field.id,
+            "form_id": form_field.form_id,
+            "field_type": (
+                form_field.field_type.value if form_field.field_type else None
+            ),
+            "label": form_field.label,
+            "name": form_field.name,
+            "placeholder": form_field.placeholder,
+            "help_text": form_field.help_text,
+            "is_required": form_field.is_required,
+            "order": form_field.order,
+            "options": form_field.options,
+            "validation": form_field.validation,
+            "default_value": form_field.default_value,
+            "entity_type_id": form_field.entity_type_id,
+            "created_date": (
+                form_field.created_date.isoformat() if form_field.created_date else None
+            ),
+            "modified_date": (
+                form_field.modified_date.isoformat()
+                if form_field.modified_date
+                else None
+            ),
+        }
+
     def _serialize_test_question(
         self, test_question: TestQuestion, organization_id: int | None
     ) -> dict[str, Any]:
@@ -1119,6 +1338,52 @@ class DataSyncService:
             "state_id": user_state.state_id,
             "created_date": (
                 user_state.created_date.isoformat() if user_state.created_date else None
+            ),
+        }
+
+    def _serialize_certificate(self, certificate: Certificate) -> dict[str, Any]:
+        return {
+            "id": certificate.id,
+            "name": certificate.name,
+            "description": certificate.description,
+            "url": certificate.url,
+            "is_active": certificate.is_active,
+            "organization_id": certificate.organization_id,
+            "created_by_id": certificate.created_by_id,
+            "created_date": (
+                certificate.created_date.isoformat()
+                if certificate.created_date
+                else None
+            ),
+            "modified_date": (
+                certificate.modified_date.isoformat()
+                if certificate.modified_date
+                else None
+            ),
+        }
+
+    def _serialize_test_state(
+        self, test_state: TestState, organization_id: int | None
+    ) -> dict[str, Any]:
+        return {
+            "id": test_state.id,
+            "test_id": test_state.test_id,
+            "state_id": test_state.state_id,
+            "organization_id": organization_id,
+            "created_date": (
+                test_state.created_date.isoformat() if test_state.created_date else None
+            ),
+        }
+
+    def _serialize_user_district(self, user_district: UserDistrict) -> dict[str, Any]:
+        return {
+            "id": user_district.id,
+            "user_id": user_district.user_id,
+            "district_id": user_district.district_id,
+            "created_date": (
+                user_district.created_date.isoformat()
+                if user_district.created_date
+                else None
             ),
         }
 

--- a/backend/app/services/datasync/bigquery.py
+++ b/backend/app/services/datasync/bigquery.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
+from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from google.oauth2 import service_account
 
@@ -326,6 +327,7 @@ class BigQueryService:
                     {"name": "marking_scheme", "type": "JSON", "mode": "NULLABLE"},
                     {"name": "created_by_id", "type": "INTEGER", "mode": "NULLABLE"},
                     {"name": "organization_id", "type": "INTEGER", "mode": "NULLABLE"},
+                    {"name": "form_id", "type": "INTEGER", "mode": "NULLABLE"},
                     {"name": "created_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
                     {"name": "modified_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
                 ],
@@ -486,7 +488,7 @@ class BigQueryService:
                     {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
                     {"name": "name", "type": "STRING", "mode": "REQUIRED"},
                     {"name": "description", "type": "STRING", "mode": "NULLABLE"},
-                    {"name": "tag_type_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "tag_type_id", "type": "INTEGER", "mode": "NULLABLE"},
                     {"name": "organization_id", "type": "INTEGER", "mode": "REQUIRED"},
                     {"name": "is_active", "type": "BOOLEAN", "mode": "REQUIRED"},
                     {"name": "created_by_id", "type": "INTEGER", "mode": "NULLABLE"},
@@ -504,7 +506,6 @@ class BigQueryService:
                     {"name": "description", "type": "STRING", "mode": "NULLABLE"},
                     {"name": "organization_id", "type": "INTEGER", "mode": "REQUIRED"},
                     {"name": "is_active", "type": "BOOLEAN", "mode": "REQUIRED"},
-                    {"name": "is_deleted", "type": "BOOLEAN", "mode": "REQUIRED"},
                     {"name": "created_by_id", "type": "INTEGER", "mode": "NULLABLE"},
                     {"name": "created_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
                     {"name": "modified_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
@@ -544,7 +545,6 @@ class BigQueryService:
                     {"name": "marking_scheme", "type": "JSON", "mode": "NULLABLE"},
                     {"name": "solution", "type": "STRING", "mode": "NULLABLE"},
                     {"name": "media", "type": "JSON", "mode": "NULLABLE"},
-                    {"name": "is_deleted", "type": "BOOLEAN", "mode": "REQUIRED"},
                     {"name": "created_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
                     {"name": "modified_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
                 ],
@@ -566,6 +566,43 @@ class BigQueryService:
                 ],
                 partition_field="created_date",
                 clustering_fields=["organization_id", "candidate_test_id", "entity_id"],
+            ),
+            "forms": TableSchema(
+                table_name=self.get_table_name("forms"),
+                columns=[
+                    {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "name", "type": "STRING", "mode": "REQUIRED"},
+                    {"name": "description", "type": "STRING", "mode": "NULLABLE"},
+                    {"name": "is_active", "type": "BOOLEAN", "mode": "REQUIRED"},
+                    {"name": "organization_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "created_by_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "created_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
+                    {"name": "modified_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
+                ],
+                partition_field="created_date",
+                clustering_fields=["organization_id"],
+            ),
+            "form_fields": TableSchema(
+                table_name=self.get_table_name("form_fields"),
+                columns=[
+                    {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "form_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "field_type", "type": "STRING", "mode": "REQUIRED"},
+                    {"name": "label", "type": "STRING", "mode": "REQUIRED"},
+                    {"name": "name", "type": "STRING", "mode": "REQUIRED"},
+                    {"name": "placeholder", "type": "STRING", "mode": "NULLABLE"},
+                    {"name": "help_text", "type": "STRING", "mode": "NULLABLE"},
+                    {"name": "is_required", "type": "BOOLEAN", "mode": "REQUIRED"},
+                    {"name": "order", "type": "INTEGER", "mode": "NULLABLE"},
+                    {"name": "options", "type": "JSON", "mode": "NULLABLE"},
+                    {"name": "validation", "type": "JSON", "mode": "NULLABLE"},
+                    {"name": "default_value", "type": "STRING", "mode": "NULLABLE"},
+                    {"name": "entity_type_id", "type": "INTEGER", "mode": "NULLABLE"},
+                    {"name": "created_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
+                    {"name": "modified_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
+                ],
+                partition_field="created_date",
+                clustering_fields=["form_id"],
             ),
             "form_responses": TableSchema(
                 table_name=self.get_table_name("form_responses"),
@@ -639,12 +676,147 @@ class BigQueryService:
                 partition_field="created_date",
                 clustering_fields=["user_id", "state_id"],
             ),
+            "certificates": TableSchema(
+                table_name=self.get_table_name("certificates"),
+                columns=[
+                    {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "name", "type": "STRING", "mode": "REQUIRED"},
+                    {"name": "description", "type": "STRING", "mode": "NULLABLE"},
+                    {"name": "url", "type": "STRING", "mode": "REQUIRED"},
+                    {"name": "is_active", "type": "BOOLEAN", "mode": "REQUIRED"},
+                    {"name": "organization_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "created_by_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "created_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
+                    {"name": "modified_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
+                ],
+                partition_field="created_date",
+                clustering_fields=["organization_id"],
+            ),
+            "test_states": TableSchema(
+                table_name=self.get_table_name("test_states"),
+                columns=[
+                    {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "test_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "state_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "organization_id", "type": "INTEGER", "mode": "NULLABLE"},
+                    {"name": "created_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
+                ],
+                partition_field="created_date",
+                clustering_fields=["organization_id", "test_id", "state_id"],
+            ),
+            "user_districts": TableSchema(
+                table_name=self.get_table_name("user_districts"),
+                columns=[
+                    {"name": "id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "user_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "district_id", "type": "INTEGER", "mode": "REQUIRED"},
+                    {"name": "created_date", "type": "TIMESTAMP", "mode": "NULLABLE"},
+                ],
+                partition_field="created_date",
+                clustering_fields=["user_id", "district_id"],
+            ),
         }
 
         if table_name not in schemas:
             raise ValueError(f"Unknown table schema: {table_name}")
 
         return schemas[table_name]
+
+    def upgrade_schemas(self) -> dict[str, dict[str, list[str]]]:
+        """Compare local schemas against BigQuery and apply missing columns
+        and column mode changes (e.g. REQUIRED -> NULLABLE).
+
+        Returns dict of table_name -> {"added": [...], "relaxed": [...]}."""
+        client = self.initialize_client()
+        dataset_id = self.config["dataset_id"]
+        changes: dict[str, dict[str, list[str]]] = {}
+
+        # Get all table names from local schema definitions
+        schemas = {
+            name: self._get_table_schema(name)
+            for name in [
+                "users",
+                "tests",
+                "questions",
+                "candidates",
+                "candidate_test_answers",
+                "candidate_tests",
+                "states",
+                "districts",
+                "blocks",
+                "entities",
+                "entity_types",
+                "tags",
+                "tag_types",
+                "question_tags",
+                "question_revisions",
+                "candidate_test_profiles",
+                "forms",
+                "form_fields",
+                "form_responses",
+                "test_questions",
+                "test_tags",
+                "test_districts",
+                "user_states",
+                "certificates",
+                "test_states",
+                "user_districts",
+            ]
+        }
+
+        for schema in schemas.values():
+            table_name = schema.table_name
+            table_ref = client.dataset(dataset_id).table(table_name)
+
+            # Check if the table exists
+            try:
+                bq_table = client.get_table(table_ref)
+            except NotFound:
+                # Table doesn't exist yet — it will be created on next sync
+                continue
+
+            # Build lookup of existing BigQuery columns: name -> SchemaField
+            existing_fields = {field.name: field for field in bq_table.schema}
+
+            added: list[str] = []
+            relaxed: list[str] = []
+
+            for column in schema.columns:
+                col_name = column["name"]
+                col_type = column["type"]
+                local_mode = column.get("mode", "NULLABLE")
+
+                if col_name not in existing_fields:
+                    # Add missing column
+                    alter_sql = (
+                        f"ALTER TABLE `{dataset_id}.{table_name}` "
+                        f"ADD COLUMN `{col_name}` {col_type}"
+                    )
+                    query_job = client.query(alter_sql)
+                    query_job.result()
+                    added.append(col_name)
+                elif (
+                    existing_fields[col_name].mode == "REQUIRED"
+                    and local_mode == "NULLABLE"
+                ):
+                    # Relax REQUIRED -> NULLABLE
+                    alter_sql = (
+                        f"ALTER TABLE `{dataset_id}.{table_name}` "
+                        f"ALTER COLUMN `{col_name}` DROP NOT NULL"
+                    )
+                    query_job = client.query(alter_sql)
+                    query_job.result()
+                    relaxed.append(col_name)
+
+            table_changes: dict[str, list[str]] = {}
+            if added:
+                table_changes["added"] = added
+            if relaxed:
+                table_changes["relaxed"] = relaxed
+            if table_changes:
+                changes[table_name] = table_changes
+
+        return changes
 
     def execute_full_sync(self, export_data: dict[str, Any]) -> SyncResult:
         """Execute a full data synchronization (replace mode)"""

--- a/backend/scripts/export_bigquery.py
+++ b/backend/scripts/export_bigquery.py
@@ -4,11 +4,14 @@ BigQuery Data Export Script
 
 This script exports data from PostgreSQL to BigQuery for one or all organizations.
 It can perform full or incremental syncs based on the options provided.
+It also supports upgrading BigQuery table schemas to add missing columns.
 
 Usage:
     python export_bigquery.py --org-id 1 --incremental
     python export_bigquery.py --all-orgs --full-sync
     python export_bigquery.py --test-connections
+    python export_bigquery.py --upgrade-schema --org-id 1
+    python export_bigquery.py --upgrade-schema --all-orgs
 """
 
 import argparse
@@ -321,6 +324,41 @@ def print_export_summary(results: dict[str, Any]) -> None:
         print(f"Sync Time: {result.sync_timestamp}")
 
 
+def _log_upgrade_results(
+    results: dict[int, dict[str, dict[str, dict[str, list[str]]]]],
+) -> None:
+    """Log the results of a schema upgrade."""
+    if not results:
+        logger.info("No schema changes needed for any organization.")
+        return
+
+    for org_id, provider_results in results.items():
+        for provider_key, table_changes in provider_results.items():
+            if "_error" in table_changes:
+                errors = table_changes["_error"].get("errors", [])
+                logger.error(
+                    f"Organization {org_id} ({provider_key}): "
+                    f"upgrade failed - {'; '.join(errors)}"
+                )
+            elif not table_changes:
+                logger.info(
+                    f"Organization {org_id} ({provider_key}): all schemas up to date"
+                )
+            else:
+                for table_name, change_details in table_changes.items():
+                    added = change_details.get("added", [])
+                    relaxed = change_details.get("relaxed", [])
+                    parts = []
+                    if added:
+                        parts.append(f"added columns: {', '.join(added)}")
+                    if relaxed:
+                        parts.append(f"relaxed to NULLABLE: {', '.join(relaxed)}")
+                    logger.info(
+                        f"Organization {org_id} ({provider_key}): "
+                        f"{table_name} - {'; '.join(parts)}"
+                    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Export Sashakt data to BigQuery",
@@ -330,6 +368,8 @@ Examples:
   python export_bigquery.py --org-id 1 --incremental
   python export_bigquery.py --all-orgs --full-sync
   python export_bigquery.py --test-connections
+  python export_bigquery.py --upgrade-schema --org-id 1
+  python export_bigquery.py --upgrade-schema --all-orgs
         """,
     )
 
@@ -357,6 +397,13 @@ Examples:
         "--full-sync", action="store_true", help="Perform full sync (replaces all data)"
     )
 
+    # Schema upgrade option
+    parser.add_argument(
+        "--upgrade-schema",
+        action="store_true",
+        help="Upgrade BigQuery table schemas (add missing columns, relax REQUIRED to NULLABLE) instead of syncing data",
+    )
+
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Enable verbose logging"
     )
@@ -369,6 +416,20 @@ Examples:
     # Handle different execution modes
     if args.test_connections:
         test_all_connections()
+    elif args.upgrade_schema:
+        if args.org_id:
+            logger.info(f"Upgrading BigQuery schemas for organization {args.org_id}...")
+            upgrade_results = data_sync_service.upgrade_organization_schemas(
+                args.org_id
+            )
+            _log_upgrade_results({args.org_id: upgrade_results})
+        elif args.all_orgs:
+            logger.info("Upgrading BigQuery schemas for all organizations...")
+            upgrade_results = data_sync_service.upgrade_all_organizations_schemas()
+            _log_upgrade_results(upgrade_results)
+        else:
+            logger.error("--upgrade-schema requires --org-id or --all-orgs")
+            sys.exit(1)
     elif args.org_id:
         incremental = not args.full_sync
         results, table_counts = export_organization_data(args.org_id, incremental)


### PR DESCRIPTION
merge 1.4 to main.

… (#401)

* add form related tables to bg sync

* add update-schema option for big query sync

* feedback fixes

* more fixes

* add missing tables for bqsync



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BigQuery schema upgrade capability for individual organizations and all organizations simultaneously
  * Extended data extraction to include forms, certificates, test states, and user districts
  * Introduced command-line interface for schema upgrades with flexible filtering options

* **Enhancements**
  * Extended existing data payloads with additional form-related fields and improved data relationships

<!-- end of auto-generated comment: release notes by coderabbit.ai -->