### PR TITLE
include organization_name in UserPublic response

### DIFF
--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -6,7 +6,7 @@ from sqlmodel import Session, select
 from app.core.config import settings
 from app.core.roles import state_admin, test_admin
 from app.core.security import create_access_token, get_password_hash, verify_password
-from app.models import District, Permission, Role, RolePermission, State
+from app.models import District, Organization, Permission, Role, RolePermission, State
 from app.models.user import (
     User,
     UserCreate,
@@ -62,6 +62,11 @@ def get_user_public(*, session: Session, db_user: User) -> UserPublic:
     role_name = role.name if role else "N/A"
     role_label = role.label if role else "N/A"
 
+    organization = session.exec(
+        select(Organization).where(Organization.id == db_user.organization_id)
+    ).first()
+    organization_name = organization.name if organization else "N/A"
+
     states = None
     districts = None
     if role_name == state_admin.name or role_name == test_admin.name:
@@ -90,6 +95,7 @@ def get_user_public(*, session: Session, db_user: User) -> UserPublic:
         phone=db_user.phone,
         role_id=db_user.role_id,
         organization_id=db_user.organization_id,
+        organization_name=organization_name,
         created_by_id=db_user.created_by_id,
         is_active=db_user.is_active,
         role_label=role_label,

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -149,6 +149,7 @@ class User(UserBase, table=True):
 class UserPublic(UserBase):
     id: int
     organization_id: int
+    organization_name: str
     role_label: str
     created_date: datetime
     modified_date: datetime

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -51,6 +51,33 @@ def test_get_users_normal_user_me(
     assert current_user["email"] == settings.EMAIL_TEST_USER
 
 
+def test_get_users_me_includes_organization_name(
+    client: TestClient, db: Session
+) -> None:
+    """organization_name in /me response matches the user's actual organization."""
+    organization = create_random_organization(db)
+    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
+    assert role is not None
+
+    user_in = UserCreate(
+        email=random_email(),
+        password=random_lower_string(),
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        role_id=role.id,
+        organization_id=organization.id,
+    )
+    user = crud.create_user(session=db, user_create=user_in)
+    headers = {"Authorization": f"Bearer {user.token}"}
+
+    r = client.get(f"{settings.API_V1_STR}/users/me", headers=headers)
+    assert r.status_code == 200
+    current_user = r.json()
+    assert "organization_name" in current_user
+    assert current_user["organization_name"] == organization.name
+    assert current_user["organization_id"] == organization.id
+
+
 def test_get_logged_user_me_permissions(
     client: TestClient, get_user_systemadmin_token: dict[str, str], db: Session
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes issue: #454 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User profiles now include the associated organization name when retrieving user information via the API. The organization name displays in user detail responses, with "N/A" shown if no organization is linked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->