### PR TITLE
Display State level tests for a district level user

### DIFF
--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -860,11 +860,26 @@ def get_test(
                 .distinct()
             )
 
-            # show unassigned tests OR tests matching users district
+            # tests assigned to the state(s) the user's districts belong to
+            current_user_state_ids_from_districts = [
+                district.state_id
+                for district in (current_user.districts or [])
+                if district.state_id is not None
+            ]
+            state_subquery = (
+                select(TestState.test_id)
+                .where(
+                    col(TestState.state_id).in_(current_user_state_ids_from_districts)
+                )
+                .distinct()
+            )
+
+            # show unassigned tests OR tests matching users district OR tests matching users state
             query = query.where(
                 or_(
                     no_location_assigned,
                     col(Test.id).in_(district_subquery),
+                    col(Test.id).in_(state_subquery),
                 )
             )
         else:

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -871,6 +871,13 @@ def get_test(
                 .where(
                     col(TestState.state_id).in_(current_user_state_ids_from_districts)
                 )
+                .where(
+                    ~exists(
+                        select(TestDistrict.test_id).where(
+                            TestDistrict.test_id == TestState.test_id
+                        )
+                    )
+                )
                 .distinct()
             )
 

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -7712,7 +7712,8 @@ def test_get_tests_by_district_user(
     assert response.status_code == 200
     data = response.json()
     items = data["items"]
-    assert len(items) == 1
+    # district user sees their own district's tests + tests assigned to their state
+    assert len(items) == 2
 
 
 def test_create_test_show_mark_for_review_true(

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -7687,7 +7687,7 @@ def test_get_tests_by_district_user(
         headers=get_user_superadmin_token,
     )
     assert response.status_code == 200
-    data = response.json()
+    test_1_name = response.json()["name"]
 
     response = client.post(
         f"{settings.API_V1_STR}/test/",
@@ -7695,7 +7695,7 @@ def test_get_tests_by_district_user(
         headers=get_user_superadmin_token,
     )
     assert response.status_code == 200
-    data = response.json()
+    test_11_name = response.json()["name"]
 
     response = client.post(
         f"{settings.API_V1_STR}/test/",
@@ -7703,7 +7703,26 @@ def test_get_tests_by_district_user(
         headers=get_user_superadmin_token,
     )
     assert response.status_code == 200
-    data = response.json()
+    test_2_name = response.json()["name"]
+
+    # test assigned to state_1 only (no district) — should be visible to user in district_1
+    test_state_only_payload = {
+        "name": random_lower_string(),
+        "description": random_lower_string(),
+        "time_limit": 30,
+        "marks": 10,
+        "link": random_lower_string(),
+        "is_active": True,
+        "locale": "en-US",
+        "state_ids": [state_1.id],
+    }
+    response = client.post(
+        f"{settings.API_V1_STR}/test/",
+        json=test_state_only_payload,
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == 200
+    test_state_only_name = response.json()["name"]
 
     response = client.get(
         f"{settings.API_V1_STR}/test/",
@@ -7712,8 +7731,14 @@ def test_get_tests_by_district_user(
     assert response.status_code == 200
     data = response.json()
     items = data["items"]
-    # district user sees their own district's tests + tests assigned to their state
+    returned_names = {item["name"] for item in items}
+    # district user sees: test_1 (own district) + test_state_only (state, no district)
+    # test_11 (same state but different district) and test_2 (different state) are excluded
     assert len(items) == 2
+    assert test_1_name in returned_names
+    assert test_state_only_name in returned_names
+    assert test_11_name not in returned_names
+    assert test_2_name not in returned_names
 
 
 def test_create_test_show_mark_for_review_true(


### PR DESCRIPTION
## Summary

Fixes issue: #475


## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * District-scoped administrators can now view tests assigned to their state, in addition to district-assigned and unassigned tests.
* **Tests**
  * Updated test coverage to verify that district users see tests tied to their districts and to their state (without district assignments), and that unrelated tests are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->