### PR TITLE
Clarify mandatory question set limit validation

### DIFF
--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -490,8 +490,10 @@ def validate_test_membership_payload(
                 raise HTTPException(
                     status_code=400,
                     detail=(
-                        "Question set max_questions_allowed_to_attempt cannot be less "
-                        "than the number of mandatory questions in that set."
+                        f"Question set '{question_set.title}' has "
+                        f"{mandatory_question_count} mandatory question(s), but only "
+                        f"{question_set.max_questions_allowed_to_attempt} question(s) "
+                        "can be attempted."
                     ),
                 )
 

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -871,7 +871,7 @@ def test_create_sectioned_test_rejects_mandatory_questions_exceeding_attempt_lim
 
     assert response.status_code == 400
     assert response.json()["detail"] == (
-        "Question set max_questions_allowed_to_attempt cannot be less than the number of mandatory questions in that set."
+        "Question set 'Physics' has 2 mandatory question(s), but only 1 question(s) can be attempted."
     )
 
 
@@ -2898,7 +2898,7 @@ def test_update_test_rejects_mandatory_questions_exceeding_attempt_limit(
 
     assert response.status_code == 400
     assert response.json()["detail"] == (
-        "Question set max_questions_allowed_to_attempt cannot be less than the number of mandatory questions in that set."
+        "Question set 'Physics' has 2 mandatory question(s), but only 1 question(s) can be attempted."
     )
 
 


### PR DESCRIPTION
## Why
A section can become impossible for candidates if it has more mandatory questions than the number of questions they are allowed to attempt.

## What
- Keeps backend create/update validation for this invariant.
- Returns a section-specific error with the mandatory count and attempt limit.
- Updates the existing route tests for the clearer error.

## Review
- Check that validation still runs for both create and update question-set payloads.
- Check that no unrelated upload settings or model changes are included.

## Tests
- `uv run ruff check app/api/routes/test.py app/tests/api/routes/test_test.py`
- `PROJECT_NAME="Sashakt Platform" POSTGRES_SERVER=localhost POSTGRES_USER=postgres POSTGRES_PASSWORD=password POSTGRES_DB=sashakt-app FIRST_SUPERUSER=admin@example.com FIRST_SUPERUSER_PASSWORD=changethis UPLOAD_ROOT=/tmp/app/uploads uv run pytest app/tests/api/routes/test_test.py -k "mandatory_questions_exceeding_attempt_limit"`

Note: the `UPLOAD_ROOT` env was only a local temporary test override for the existing `/app/uploads` bootstrap issue and is not part of this PR.