### PR TITLE
Remove is_reviewed field from answer submission

### DIFF
--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -942,7 +942,6 @@ def submit_answer_for_qr_candidate(
         existing_answer.visited = answer_request.visited
         existing_answer.time_spent = answer_request.time_spent
         existing_answer.bookmarked = answer_request.bookmarked
-        existing_answer.is_reviewed = answer_request.is_reviewed
         session.add(existing_answer)
         session.commit()
         session.refresh(existing_answer)
@@ -956,7 +955,6 @@ def submit_answer_for_qr_candidate(
             visited=answer_request.visited,
             time_spent=answer_request.time_spent,
             bookmarked=answer_request.bookmarked,
-            is_reviewed=answer_request.is_reviewed,
         )
         session.add(candidate_test_answer)
         session.commit()

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -87,7 +87,6 @@ class CandidateTestAnswerUpdate(SQLModel):
     visited: bool
     time_spent: int
     bookmarked: bool | None = None
-    is_reviewed: bool = False
 
 
 # QR Code Candidate Request Models
@@ -99,7 +98,6 @@ class CandidateAnswerSubmitRequest(SQLModel):
     visited: bool = False
     time_spent: int = 0
     bookmarked: bool = False
-    is_reviewed: bool = False
 
 
 class BatchAnswerSubmitRequest(SQLModel):

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -12508,7 +12508,7 @@ def test_get_test_result_with_numerical_decimal_tolerance(
 def test_submit_answer_saves_is_reviewed_field(
     client: TestClient, db: SessionDep
 ) -> None:
-    """Test that is_reviewed field is correctly saved when submitting an answer."""
+    """Test that is_reviewed cannot be set via the submit answer API; it always defaults to False."""
     user = create_random_user(db)
 
     org = Organization(name=random_lower_string())
@@ -12566,7 +12566,6 @@ def test_submit_answer_saves_is_reviewed_field(
         "response": "[1]",
         "visited": True,
         "time_spent": 30,
-        "is_reviewed": True,
     }
 
     response = client.post(
@@ -12582,7 +12581,7 @@ def test_submit_answer_saves_is_reviewed_field(
         .where(CandidateTestAnswer.question_revision_id == question_revision.id)
     ).first()
     assert answer is not None
-    assert answer.is_reviewed is True
+    assert answer.is_reviewed is False
 
 
 def test_submit_answer_is_reviewed_defaults_to_false(


### PR DESCRIPTION
## Summary

Fixes issue: #403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Candidate answer submissions no longer accept a client-supplied "reviewed" flag; the reviewed status is now controlled through the review flow, ensuring submissions keep a consistent reviewed state.
* **Tests**
  * Added/updated tests to confirm the reviewed flag defaults to false and cannot be set via the submit-answer payload.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-core/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->