### PR TITLE
Add is_active filter to organization endpoints

### DIFF
--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -201,6 +201,7 @@ def get_organization(
     description: str | None = Query(
         None, description="Filter by organization description", min_length=3
     ),
+    is_active: bool | None = Query(None, description="Filter by active status"),
     order_by: list[str] = Query(
         default=["created_date"],
         title="Order by",
@@ -210,7 +211,6 @@ def get_organization(
 ) -> Page[OrganizationPublic]:
     query = select(Organization).where(
         not_(Organization.is_deleted),
-        Organization.is_active == True,  # noqa: E712
     )
 
     if name:
@@ -218,6 +218,9 @@ def get_organization(
 
     if description:
         query = query.where(col(Organization.description).contains(description))
+
+    if is_active is not None:
+        query = query.where(Organization.is_active == is_active)  # noqa: E712
 
     for order in order_by:
         is_desc = order.startswith("-")

--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -41,8 +41,20 @@ from app.models.user import UserDistrict, UserState
 router = APIRouter(prefix="/organization", tags=["Organization"])
 
 
+def _get_user_count_map(session: SessionDep, org_ids: list[int]) -> dict[int, int]:
+    if not org_ids:
+        return {}
+    rows = session.exec(
+        select(col(User.organization_id), func.count(col(User.id)))
+        .where(col(User.organization_id).in_(org_ids))
+        .group_by(col(User.organization_id))
+    ).all()
+    return dict(rows)
+
+
 def transform_organizations_to_public(
     items: list[Organization] | Any,
+    user_count_map: dict[int, int] | None = None,
 ) -> list[OrganizationPublic]:
     result: list[OrganizationPublic] = []
     organization_list: list[Organization] = (
@@ -52,9 +64,20 @@ def transform_organizations_to_public(
     for organization in organization_list:
         org_data = organization.model_dump()
         org_data["logo"] = get_absolute_logo_url(org_data.get("logo"))
+        if user_count_map is not None and organization.id is not None:
+            org_data["users_count"] = user_count_map.get(organization.id, 0)
         result.append(OrganizationPublic(**org_data))
 
     return result
+
+
+def _org_page_transformer(
+    session: SessionDep, items: list[Organization] | Any
+) -> list[OrganizationPublic]:
+    org_list: list[Organization] = list(items) if not isinstance(items, list) else items
+    org_ids = [org.id for org in org_list if org.id is not None]
+    count_map = _get_user_count_map(session, org_ids)
+    return transform_organizations_to_public(org_list, count_map)
 
 
 @router.get(
@@ -237,7 +260,7 @@ def get_organization(
         session,
         query,  # type: ignore[arg-type]
         params,
-        transformer=lambda items: transform_organizations_to_public(items),
+        transformer=lambda items: _org_page_transformer(session, items),
     )
 
     return organizations

--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -1,5 +1,6 @@
 import copy
-from typing import Any, cast
+from collections.abc import Sequence
+from typing import cast
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from fastapi_pagination import Page
@@ -46,22 +47,22 @@ def _get_user_count_map(session: SessionDep, org_ids: list[int]) -> dict[int, in
         return {}
     rows = session.exec(
         select(col(User.organization_id), func.count(col(User.id)))
-        .where(col(User.organization_id).in_(org_ids))
+        .where(
+            col(User.organization_id).in_(org_ids),
+            User.is_active == True,  # noqa: E712
+        )
         .group_by(col(User.organization_id))
     ).all()
     return dict(rows)
 
 
 def transform_organizations_to_public(
-    items: list[Organization] | Any,
+    items: Sequence[Organization],
     user_count_map: dict[int, int] | None = None,
 ) -> list[OrganizationPublic]:
     result: list[OrganizationPublic] = []
-    organization_list: list[Organization] = (
-        list(items) if not isinstance(items, list) else items
-    )
 
-    for organization in organization_list:
+    for organization in items:
         org_data = organization.model_dump()
         org_data["logo"] = get_absolute_logo_url(org_data.get("logo"))
         if user_count_map is not None and organization.id is not None:
@@ -72,12 +73,11 @@ def transform_organizations_to_public(
 
 
 def _org_page_transformer(
-    session: SessionDep, items: list[Organization] | Any
+    session: SessionDep, items: Sequence[Organization]
 ) -> list[OrganizationPublic]:
-    org_list: list[Organization] = list(items) if not isinstance(items, list) else items
-    org_ids = [org.id for org in org_list if org.id is not None]
+    org_ids = [org.id for org in items if org.id is not None]
     count_map = _get_user_count_map(session, org_ids)
-    return transform_organizations_to_public(org_list, count_map)
+    return transform_organizations_to_public(items, count_map)
 
 
 @router.get(

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -15,7 +15,13 @@ from app.api.deps import (
 )
 from app.api.routes.utils import get_current_user_location_ids
 from app.core.config import settings
-from app.core.roles import can_assign_role, state_admin, test_admin
+from app.core.roles import (
+    can_assign_role,
+    state_admin,
+    super_admin,
+    system_admin,
+    test_admin,
+)
 from app.core.security import get_password_hash, verify_password
 from app.core.sorting import (
     SortingParams,
@@ -146,7 +152,15 @@ def read_users(
     """
     current_user_organization_id = current_user.organization_id
 
-    statement = select(User).where(User.organization_id == current_user_organization_id)
+    if current_user.role.name == super_admin.name:
+        admin_role_ids = select(Role.id).where(
+            col(Role.name).in_([super_admin.name, system_admin.name])
+        )
+        statement = select(User).where(col(User.role_id).in_(admin_role_ids))
+    else:
+        statement = select(User).where(
+            User.organization_id == current_user_organization_id
+        )
 
     # apply role-based filtering
     if (

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -490,8 +490,22 @@ def read_user_by_id(
     Get a specific user by id.
     """
     user = session.get(User, user_id)
-    if not user or user.organization_id != current_user.organization_id:
+    if not user:
         raise HTTPException(status_code=404, detail="User not found")
+
+    if user.organization_id != current_user.organization_id:
+        admin_role_ids = set(
+            session.exec(
+                select(Role.id).where(
+                    col(Role.name).in_([super_admin.name, system_admin.name])
+                )
+            ).all()
+        )
+        if (
+            current_user.role.name != super_admin.name
+            or user.role_id not in admin_role_ids
+        ):
+            raise HTTPException(status_code=404, detail="User not found")
 
     # check location based access for state/district admins
     # skip check if user is reading their own profile

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -51,6 +51,12 @@ UserSorting = create_sorting_dependency(UserSortConfig)
 UserSortingDep = Annotated[SortingParams, Depends(UserSorting)]
 
 
+def _admin_role_ids_subquery() -> Any:
+    return select(Role.id).where(
+        col(Role.name).in_([super_admin.name, system_admin.name])
+    )
+
+
 def _assign_locations(
     session: SessionDep,
     user_id: int,
@@ -153,10 +159,9 @@ def read_users(
     current_user_organization_id = current_user.organization_id
 
     if current_user.role.name == super_admin.name:
-        admin_role_ids = select(Role.id).where(
-            col(Role.name).in_([super_admin.name, system_admin.name])
+        statement = select(User).where(
+            col(User.role_id).in_(_admin_role_ids_subquery())
         )
-        statement = select(User).where(col(User.role_id).in_(admin_role_ids))
     else:
         statement = select(User).where(
             User.organization_id == current_user_organization_id
@@ -494,17 +499,10 @@ def read_user_by_id(
         raise HTTPException(status_code=404, detail="User not found")
 
     if user.organization_id != current_user.organization_id:
-        admin_role_ids = set(
-            session.exec(
-                select(Role.id).where(
-                    col(Role.name).in_([super_admin.name, system_admin.name])
-                )
-            ).all()
-        )
-        if (
-            current_user.role.name != super_admin.name
-            or user.role_id not in admin_role_ids
-        ):
+        is_admin_role = session.exec(
+            _admin_role_ids_subquery().where(Role.id == user.role_id)
+        ).first()
+        if current_user.role.name != super_admin.name or not is_admin_role:
             raise HTTPException(status_code=404, detail="User not found")
 
     # check location based access for state/district admins

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -68,7 +68,7 @@ class OrganizationPublic(OrganizationBase):
     created_date: datetime | None
     modified_date: datetime | None
     is_deleted: bool
-    users_count: int = 0
+    users_count: int | None = None
 
 
 class OrganizationUpdate(OrganizationBase):

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -68,6 +68,7 @@ class OrganizationPublic(OrganizationBase):
     created_date: datetime | None
     modified_date: datetime | None
     is_deleted: bool
+    users_count: int = 0
 
 
 class OrganizationUpdate(OrganizationBase):

--- a/backend/app/tests/api/routes/test_organization.py
+++ b/backend/app/tests/api/routes/test_organization.py
@@ -1648,3 +1648,134 @@ def test_update_organization_logo_no_filename(
     )
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_read_organization_list_includes_users_count(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    user_a = create_random_user(db, org.id)
+    user_b = create_random_user(db, org.id)
+    db.add_all([user_a, user_b])
+    db.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/organization/",
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    items = response.json()["items"]
+
+    org_item = next((item for item in items if item["id"] == org.id), None)
+    assert org_item is not None
+    assert org_item["users_count"] == 2
+
+
+def test_read_organization_list_users_count_multiple_orgs(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    org_a = Organization(name=random_lower_string())
+    org_b = Organization(name=random_lower_string())
+    db.add_all([org_a, org_b])
+    db.commit()
+    db.refresh(org_a)
+    db.refresh(org_b)
+
+    for _ in range(3):
+        db.add(create_random_user(db, org_a.id))
+    db.add(create_random_user(db, org_b.id))
+    db.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/organization/",
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    items = response.json()["items"]
+
+    item_a = next((item for item in items if item["id"] == org_a.id), None)
+    item_b = next((item for item in items if item["id"] == org_b.id), None)
+    assert item_a is not None
+    assert item_b is not None
+    assert item_a["users_count"] == 3
+    assert item_b["users_count"] == 1
+
+
+def test_read_organization_list_users_count_zero_for_empty_org(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    response = client.get(
+        f"{settings.API_V1_STR}/organization/",
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    items = response.json()["items"]
+
+    org_item = next((item for item in items if item["id"] == org.id), None)
+    assert org_item is not None
+    assert org_item["users_count"] == 0
+
+
+def test_read_organization_list_users_count_excludes_inactive_users(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    active_user = create_random_user(db, org.id)
+    inactive_user = create_random_user(db, org.id)
+    inactive_user.is_active = False
+    db.add_all([active_user, inactive_user])
+    db.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/organization/",
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    items = response.json()["items"]
+
+    org_item = next((item for item in items if item["id"] == org.id), None)
+    assert org_item is not None
+    assert org_item["users_count"] == 1
+
+
+def test_read_organization_by_id_users_count_is_none(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    create_random_user(db, org.id)
+    db.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/organization/{org.id}",
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["users_count"] is None

--- a/backend/app/tests/api/routes/test_organization.py
+++ b/backend/app/tests/api/routes/test_organization.py
@@ -484,31 +484,66 @@ def test_delete_organization(
     assert "id" not in data
 
 
-def test_inactive_organization_not_listed(
+def test_read_organization_shows_active_and_inactive(
     client: TestClient,
+    db: SessionDep,
     get_user_superadmin_token: dict[str, str],
 ) -> None:
-    response = client.post(
-        f"{settings.API_V1_STR}/organization/",
-        json={
-            "name": "inactive org",
-            "description": "organization is not active",
-            "is_active": False,
-        },
-        headers=get_user_superadmin_token,
-    )
-    data = response.json()
-    assert response.status_code == 200
-    org_id = data["id"]
-    assert data["is_active"] is False
+    active_org = Organization(name=random_lower_string(), is_active=True)
+    inactive_org = Organization(name=random_lower_string(), is_active=False)
+    db.add_all([active_org, inactive_org])
+    db.commit()
 
     response = client.get(
         f"{settings.API_V1_STR}/organization/",
         headers=get_user_superadmin_token,
     )
-    data = response.json()
-    items = data["items"]
-    assert all(item["id"] != org_id for item in items)
+    assert response.status_code == 200
+    items = response.json()["items"]
+
+    ids = [item["id"] for item in items]
+    assert active_org.id in ids
+    assert inactive_org.id in ids
+
+    active_item = next(item for item in items if item["id"] == active_org.id)
+    inactive_item = next(item for item in items if item["id"] == inactive_org.id)
+    assert active_item["is_active"] is True
+    assert inactive_item["is_active"] is False
+
+
+def test_read_organization_filter_by_is_active(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    active_org = Organization(name=random_lower_string(), is_active=True)
+    inactive_org = Organization(name=random_lower_string(), is_active=False)
+    db.add_all([active_org, inactive_org])
+    db.commit()
+
+    # Filter active only
+    response = client.get(
+        f"{settings.API_V1_STR}/organization/?is_active=true",
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    ids = [item["id"] for item in items]
+    assert active_org.id in ids
+    assert inactive_org.id not in ids
+    assert all(item["is_active"] is True for item in items)
+
+    # Filter inactive only
+    response = client.get(
+        f"{settings.API_V1_STR}/organization/?is_active=false",
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    ids = [item["id"] for item in items]
+    assert inactive_org.id in ids
+    assert active_org.id not in ids
+    assert all(item["is_active"] is False for item in items)
 
 
 def test_get_aggregated_data_for_organization(

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -433,6 +433,88 @@ def test_non_superadmin_only_sees_own_org_users(
         assert item["organization_id"] == caller_org_id
 
 
+def test_superadmin_can_read_system_admin_from_other_org(
+    client: TestClient, db: Session, get_user_superadmin_token: dict[str, str]
+) -> None:
+    """super_admin can fetch a system_admin by ID even from a different org."""
+    system_admin_role = db.exec(
+        select(Role).where(Role.name == system_admin.name)
+    ).first()
+    assert system_admin_role is not None
+
+    other_org = create_random_organization(db)
+    user_in = UserCreate(
+        email=random_email(),
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        password=random_lower_string(),
+        role_id=system_admin_role.id,
+        organization_id=other_org.id,
+    )
+    other_admin = crud.create_user(session=db, user_create=user_in)
+    assert other_admin.id is not None
+
+    r = client.get(
+        f"{settings.API_V1_STR}/users/{other_admin.id}",
+        headers=get_user_superadmin_token,
+    )
+    assert r.status_code == 200
+    assert r.json()["id"] == other_admin.id
+    assert r.json()["organization_id"] == other_org.id
+
+
+def test_superadmin_cannot_read_lower_role_user_from_other_org(
+    client: TestClient, db: Session, get_user_superadmin_token: dict[str, str]
+) -> None:
+    """super_admin cannot fetch a state_admin/test_admin by ID from a different org."""
+    state_admin_role = db.exec(
+        select(Role).where(Role.name == state_admin.name)
+    ).first()
+    assert state_admin_role is not None
+
+    other_org = create_random_organization(db)
+    user_in = UserCreate(
+        email=random_email(),
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        password=random_lower_string(),
+        role_id=state_admin_role.id,
+        organization_id=other_org.id,
+    )
+    lower_role_user = crud.create_user(session=db, user_create=user_in)
+    assert lower_role_user.id is not None
+
+    r = client.get(
+        f"{settings.API_V1_STR}/users/{lower_role_user.id}",
+        headers=get_user_superadmin_token,
+    )
+    assert r.status_code == 404
+
+
+def test_non_superadmin_cannot_read_user_from_other_org(
+    client: TestClient, db: Session, get_user_systemadmin_token: dict[str, str]
+) -> None:
+    """system_admin cannot fetch a user from a different org by ID."""
+    other_org = create_random_organization(db)
+    other_role = create_random_role(db)
+    user_in = UserCreate(
+        email=random_email(),
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        password=random_lower_string(),
+        role_id=other_role.id,
+        organization_id=other_org.id,
+    )
+    other_user = crud.create_user(session=db, user_create=user_in)
+    assert other_user.id is not None
+
+    r = client.get(
+        f"{settings.API_V1_STR}/users/{other_user.id}",
+        headers=get_user_systemadmin_token,
+    )
+    assert r.status_code == 404
+
+
 def test_update_user_me(
     client: TestClient, get_user_candidate_token: dict[str, str], db: Session
 ) -> None:

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -6,7 +6,7 @@ from sqlmodel import Session, select
 from app import crud
 from app.api.deps import SessionDep
 from app.core.config import settings
-from app.core.roles import super_admin
+from app.core.roles import state_admin, super_admin, system_admin
 from app.core.security import verify_password
 from app.models import Permission, Role, RolePermission, User, UserCreate
 from app.models.location import Country, District, State
@@ -316,34 +316,13 @@ def test_create_user_existing_username(
 def test_retrieve_users(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    current_user = get_current_user_data(client, superuser_token_headers)
-    username = random_email()
-    password = random_lower_string()
-    user_in = UserCreate(
-        email=username,
-        password=password,
-        full_name=random_lower_string(),
-        phone=random_lower_string(),
-        role_id=create_random_role(db).id,
-        organization_id=current_user["organization_id"],
-    )
-    crud.create_user(session=db, user_create=user_in)
-
-    username2 = random_email()
-    password2 = random_lower_string()
-    user_in2 = UserCreate(
-        email=username2,
-        password=password2,
-        full_name=random_lower_string(),
-        phone=random_lower_string(),
-        role_id=create_random_role(db).id,
-        organization_id=current_user["organization_id"],
-    )
-    crud.create_user(session=db, user_create=user_in2)
+    super_admin_role = db.exec(
+        select(Role).where(Role.name == super_admin.name)
+    ).first()
+    assert super_admin_role is not None
 
     r = client.get(f"{settings.API_V1_STR}/users/", headers=superuser_token_headers)
     all_users = r.json()
-    assert len(all_users["items"]) > 2
 
     assert_paginated_response(r, min_expected_total=1)
     for item in all_users["items"]:
@@ -352,7 +331,106 @@ def test_retrieve_users(
         assert "phone" in item
         assert "role_id" in item
         assert "organization_id" in item
-        assert item["organization_id"] == current_user["organization_id"]
+
+
+def test_superadmin_sees_admin_users_across_all_orgs(
+    client: TestClient, db: Session, get_user_superadmin_token: dict[str, str]
+) -> None:
+    """super_admin sees super_admin and system_admin users from ALL orgs."""
+
+    system_admin_role = db.exec(
+        select(Role).where(Role.name == system_admin.name)
+    ).first()
+    assert system_admin_role is not None
+
+    other_org = create_random_organization(db)
+    other_email = random_email()
+    user_in = UserCreate(
+        email=other_email,
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        password=random_lower_string(),
+        role_id=system_admin_role.id,
+        organization_id=other_org.id,
+    )
+    crud.create_user(session=db, user_create=user_in)
+
+    r = client.get(
+        f"{settings.API_V1_STR}/users/",
+        params={"search": other_email},
+        headers=get_user_superadmin_token,
+    )
+    assert r.status_code == 200
+    returned_emails = [item["email"] for item in r.json()["items"]]
+
+    assert other_email in returned_emails
+
+
+def test_superadmin_excludes_lower_role_users_from_other_orgs(
+    client: TestClient, db: Session, get_user_superadmin_token: dict[str, str]
+) -> None:
+    """Scenario 2: super_admin must NOT see state_admin/test_admin users from other orgs."""
+    state_admin_role = db.exec(
+        select(Role).where(Role.name == state_admin.name)
+    ).first()
+    assert state_admin_role is not None
+
+    other_org = create_random_organization(db)
+    lower_role_email = random_email()
+    user_in = UserCreate(
+        email=lower_role_email,
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        password=random_lower_string(),
+        role_id=state_admin_role.id,
+        organization_id=other_org.id,
+    )
+    crud.create_user(session=db, user_create=user_in)
+
+    res = client.get(
+        f"{settings.API_V1_STR}/users/",
+        params={"search": lower_role_email},
+        headers=get_user_superadmin_token,
+    )
+    assert res.status_code == 200
+    returned_emails = [item["email"] for item in res.json()["items"]]
+
+    assert lower_role_email not in returned_emails
+
+
+def test_non_superadmin_only_sees_own_org_users(
+    client: TestClient, db: Session, get_user_systemadmin_token: dict[str, str]
+) -> None:
+    """Scenario 3: system_admin (non-super_admin) only sees users from their own org."""
+    caller = get_current_user_data(client, get_user_systemadmin_token)
+    caller_org_id = caller["organization_id"]
+
+    other_org = create_random_organization(db)
+    other_email = random_email()
+    other_role = create_random_role(db)
+    user_in = UserCreate(
+        email=other_email,
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        password=random_lower_string(),
+        role_id=other_role.id,
+        organization_id=other_org.id,
+    )
+    crud.create_user(session=db, user_create=user_in)
+
+    r = client.get(
+        f"{settings.API_V1_STR}/users/",
+        params={"search": other_email},
+        headers=get_user_systemadmin_token,
+    )
+    assert r.status_code == 200
+    data = r.json()
+
+    returned_emails = [item["email"] for item in data["items"]]
+    assert other_email not in returned_emails
+
+    for item in data["items"]:
+        assert item["organization_id"] == caller_org_id
 
 
 def test_update_user_me(


### PR DESCRIPTION
## Summary

Fixes issue: #503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizations list supports an optional is_active filter; by default both active and inactive orgs are returned.
  * Organization list responses include per-organization users_count (counts exclude inactive users); single-organization GET returns users_count as null.
  * User listing visibility updated: super-admins can see admin-level users across orgs; non-super admins see only users from their own org.

* **Tests**
  * Added/expanded tests for active/inactive listing and filtering, users_count accuracy/exclusions, and role-based user-list visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-core/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->