### PR TITLE
Implement bulk delete functionality for certificates

### DIFF
--- a/backend/app/api/routes/certificate.py
+++ b/backend/app/api/routes/certificate.py
@@ -1,9 +1,9 @@
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Response
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlmodel import paginate
-from sqlmodel import func, select
+from sqlmodel import col, func, select
 
 from app.api.deps import CurrentUser, Pagination, SessionDep, permission_dependency
 from app.core.provider_config import provider_config_service
@@ -14,6 +14,7 @@ from app.models.certificate import (
     CertificateCreate,
     CertificatePublic,
     CertificateUpdate,
+    DeleteCertificate,
 )
 from app.models.provider import OrganizationProvider, Provider, ProviderType
 from app.models.test import Test
@@ -188,6 +189,52 @@ def delete_certificate(
     session.commit()
 
     return Message(message="Certificate deleted successfully")
+
+
+@router.delete(
+    "/",
+    response_model=DeleteCertificate,
+    dependencies=[Depends(permission_dependency("delete_certificate"))],
+)
+def bulk_delete_certificate(
+    session: SessionDep,
+    current_user: CurrentUser,
+    certificate_ids: list[int] = Body(...),
+) -> DeleteCertificate:
+    success_count = 0
+    failure_list: list[CertificatePublic] = []
+
+    db_certificates = session.exec(
+        select(Certificate).where(
+            col(Certificate.id).in_(certificate_ids),
+            Certificate.organization_id == current_user.organization_id,
+        )
+    ).all()
+
+    found_ids = {cert.id for cert in db_certificates}
+    missing_ids = set(certificate_ids) - found_ids
+    if missing_ids:
+        raise HTTPException(
+            status_code=404, detail="Invalid Certificates selected for deletion"
+        )
+
+    for certificate in db_certificates:
+        related_test = session.exec(
+            select(Test).where(Test.certificate_id == certificate.id)
+        ).first()
+
+        if related_test:
+            failure_list.append(CertificatePublic(**certificate.model_dump()))
+        else:
+            session.delete(certificate)
+            success_count += 1
+
+    session.commit()
+
+    return DeleteCertificate(
+        delete_success_count=success_count,
+        delete_failure_list=failure_list or None,
+    )
 
 
 @router.get("/download/{token}")

--- a/backend/app/api/routes/certificate.py
+++ b/backend/app/api/routes/certificate.py
@@ -159,6 +159,15 @@ def update_certificate(
     return certificate
 
 
+def _check_certificate_has_associated_test(
+    session: SessionDep, certificate_id: int
+) -> bool:
+    return (
+        session.exec(select(Test).where(Test.certificate_id == certificate_id)).first()
+        is not None
+    )
+
+
 # Delete Certificate
 @router.delete(
     "/{certificate_id}",
@@ -174,12 +183,7 @@ def delete_certificate(
     if not certificate or certificate.organization_id != current_user.organization_id:
         raise HTTPException(status_code=404, detail="Certificate not found")
 
-    # check for associated tests before deleting
-    related_tests = session.exec(
-        select(Test).where(Test.certificate_id == certificate_id)
-    ).first()
-
-    if related_tests:
+    if _check_certificate_has_associated_test(session, certificate_id):
         raise HTTPException(
             status_code=400,
             detail="Certificate has associated tests and cannot be deleted",
@@ -219,11 +223,9 @@ def bulk_delete_certificate(
         )
 
     for certificate in db_certificates:
-        related_test = session.exec(
-            select(Test).where(Test.certificate_id == certificate.id)
-        ).first()
-
-        if related_test:
+        if certificate.id is not None and _check_certificate_has_associated_test(
+            session, certificate.id
+        ):
             failure_list.append(CertificatePublic(**certificate.model_dump()))
         else:
             session.delete(certificate)

--- a/backend/app/models/certificate.py
+++ b/backend/app/models/certificate.py
@@ -61,3 +61,8 @@ class CertificatePublic(CertificateBase):
 
 class CertificateUpdate(CertificateBase):
     pass
+
+
+class DeleteCertificate(SQLModel):
+    delete_success_count: int
+    delete_failure_list: list[CertificatePublic] | None = None

--- a/backend/app/tests/api/routes/test_certificate.py
+++ b/backend/app/tests/api/routes/test_certificate.py
@@ -427,6 +427,160 @@ def test_delete_certificate_with_associated_tests(
     assert response.status_code == 200
 
 
+def test_bulk_delete_certificates_success(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    user_data = get_current_user_data(client, get_user_superadmin_token)
+    user_id = user_data["id"]
+    organization_id = user_data["organization_id"]
+
+    cert_a = Certificate(
+        name=random_lower_string(),
+        url=random_lower_string(),
+        organization_id=organization_id,
+        created_by_id=user_id,
+    )
+    cert_b = Certificate(
+        name=random_lower_string(),
+        url=random_lower_string(),
+        organization_id=organization_id,
+        created_by_id=user_id,
+    )
+    db.add_all([cert_a, cert_b])
+    db.commit()
+    db.refresh(cert_a)
+    db.refresh(cert_b)
+
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/certificate/",
+        json=[cert_a.id, cert_b.id],
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["delete_success_count"] == 2
+    assert data["delete_failure_list"] is None
+
+    assert db.get(Certificate, cert_a.id) is None
+    assert db.get(Certificate, cert_b.id) is None
+
+
+def test_bulk_delete_certificates_partial_failure_due_to_associated_tests(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    user_data = get_current_user_data(client, get_user_superadmin_token)
+    user_id = user_data["id"]
+    organization_id = user_data["organization_id"]
+
+    cert_free = Certificate(
+        name=random_lower_string(),
+        url=random_lower_string(),
+        organization_id=organization_id,
+        created_by_id=user_id,
+    )
+    cert_with_test = Certificate(
+        name=random_lower_string(),
+        url=random_lower_string(),
+        organization_id=organization_id,
+        created_by_id=user_id,
+    )
+    db.add_all([cert_free, cert_with_test])
+    db.commit()
+    db.refresh(cert_free)
+    db.refresh(cert_with_test)
+
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user_id,
+        organization_id=organization_id,
+        certificate_id=cert_with_test.id,
+    )
+    db.add(test)
+    db.commit()
+
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/certificate/",
+        json=[cert_free.id, cert_with_test.id],
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["delete_success_count"] == 1
+    assert data["delete_failure_list"] is not None
+    assert len(data["delete_failure_list"]) == 1
+    assert data["delete_failure_list"][0]["id"] == cert_with_test.id
+
+    assert db.get(Certificate, cert_free.id) is None
+    assert db.get(Certificate, cert_with_test.id) is not None
+
+
+def test_bulk_delete_certificates_missing_ids_returns_404(
+    client: TestClient,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/certificate/",
+        json=[-1, -2],
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+
+    assert response.status_code == 404
+    assert "invalid" in data["detail"].lower()
+
+
+def test_bulk_delete_certificates_all_blocked_by_tests(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    user_data = get_current_user_data(client, get_user_superadmin_token)
+    user_id = user_data["id"]
+    organization_id = user_data["organization_id"]
+
+    cert = Certificate(
+        name=random_lower_string(),
+        url=random_lower_string(),
+        organization_id=organization_id,
+        created_by_id=user_id,
+    )
+    db.add(cert)
+    db.commit()
+    db.refresh(cert)
+
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user_id,
+        organization_id=organization_id,
+        certificate_id=cert.id,
+    )
+    db.add(test)
+    db.commit()
+
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/certificate/",
+        json=[cert.id],
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["delete_success_count"] == 0
+    assert data["delete_failure_list"] is not None
+    assert data["delete_failure_list"][0]["id"] == cert.id
+    assert db.get(Certificate, cert.id) is not None
+
+
 def test_download_certificate_invalid_token(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes issue: #505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk deletion capability for certificates—delete multiple certificates in a single operation.
  * Enhanced deletion responses to show success count and list failed deletions.
  * Certificates with associated tests are now safely rejected from deletion with detailed feedback.
  * Invalid certificate IDs return a clear error message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-core/pull/506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->