### PR TITLE
Add bulk delete functionality for forms 

### DIFF
--- a/backend/app/api/routes/form.py
+++ b/backend/app/api/routes/form.py
@@ -226,6 +226,10 @@ def _check_form_has_associated_tests(form: Form) -> bool:
     return len(form.tests) > 0
 
 
+def _check_form_has_fields(form: Form) -> bool:
+    return bool(form.fields)
+
+
 def _check_form_has_responses(session: SessionDep, form_id: int) -> bool:
     return (
         session.exec(
@@ -249,6 +253,12 @@ def delete_form(
 
     if not form or form.organization_id != current_user.organization_id:
         raise HTTPException(status_code=404, detail="Form not found")
+
+    if _check_form_has_fields(form):
+        raise HTTPException(
+            status_code=400,
+            detail="This form cannot be deleted while it has associated fields. Please remove all fields before deleting the form.",
+        )
 
     if _check_form_has_associated_tests(form):
         raise HTTPException(
@@ -299,7 +309,8 @@ def bulk_delete_form(
 
     for form in db_forms:
         if form.id is not None and (
-            _check_form_has_associated_tests(form)
+            _check_form_has_fields(form)
+            or _check_form_has_associated_tests(form)
             or _check_form_has_responses(session, form.id)
         ):
             failure_list.append(build_form_public(form))

--- a/backend/app/api/routes/form.py
+++ b/backend/app/api/routes/form.py
@@ -1,14 +1,15 @@
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlmodel import paginate
 from sqlalchemy.orm import selectinload
-from sqlmodel import func, select
+from sqlmodel import col, func, select
 
 from app.api.deps import CurrentUser, Pagination, SessionDep, permission_dependency
 from app.models import Message
 from app.models.form import (
+    DeleteForm,
     Form,
     FormCreate,
     FormField,
@@ -221,6 +222,19 @@ def update_form(
     return build_form_public(form)
 
 
+def _check_form_has_associated_tests(form: Form) -> bool:
+    return len(form.tests) > 0
+
+
+def _check_form_has_responses(session: SessionDep, form_id: int) -> bool:
+    return (
+        session.exec(
+            select(FormResponse).where(FormResponse.form_id == form_id)
+        ).first()
+        is not None
+    )
+
+
 @router.delete(
     "/{form_id}",
     dependencies=[Depends(permission_dependency("delete_form"))],
@@ -236,19 +250,13 @@ def delete_form(
     if not form or form.organization_id != current_user.organization_id:
         raise HTTPException(status_code=404, detail="Form not found")
 
-    # Check if form is associated with any tests
-    if form.tests:
+    if _check_form_has_associated_tests(form):
         raise HTTPException(
             status_code=400,
             detail="Cannot delete form because it is associated with tests. Remove the form from all tests first.",
         )
 
-    # Check if form has any responses
-    has_responses = session.exec(
-        select(FormResponse).where(FormResponse.form_id == form_id)
-    ).first()
-
-    if has_responses:
+    if _check_form_has_responses(session, form_id):
         raise HTTPException(
             status_code=400,
             detail="Cannot delete form because it has submitted responses.",
@@ -258,6 +266,53 @@ def delete_form(
     session.commit()
 
     return Message(message="Form deleted successfully")
+
+
+@router.delete(
+    "/",
+    response_model=DeleteForm,
+    dependencies=[Depends(permission_dependency("delete_form"))],
+)
+def bulk_delete_form(
+    session: SessionDep,
+    current_user: CurrentUser,
+    form_ids: list[int] = Body(...),
+) -> DeleteForm:
+    success_count = 0
+    failure_list: list[FormPublic] = []
+
+    db_forms = session.exec(
+        select(Form)
+        .where(
+            col(Form.id).in_(form_ids),
+            Form.organization_id == current_user.organization_id,
+        )
+        .options(selectinload(Form.tests), selectinload(Form.fields))  # type: ignore[arg-type]
+    ).all()
+
+    found_ids = {form.id for form in db_forms}
+    missing_ids = set(form_ids) - found_ids
+    if missing_ids:
+        raise HTTPException(
+            status_code=404, detail="Invalid Forms selected for deletion"
+        )
+
+    for form in db_forms:
+        if form.id is not None and (
+            _check_form_has_associated_tests(form)
+            or _check_form_has_responses(session, form.id)
+        ):
+            failure_list.append(build_form_public(form))
+        else:
+            session.delete(form)
+            success_count += 1
+
+    session.commit()
+
+    return DeleteForm(
+        delete_success_count=success_count,
+        delete_failure_list=failure_list or None,
+    )
 
 
 # ============== FormField Management Endpoints ==============

--- a/backend/app/api/routes/form.py
+++ b/backend/app/api/routes/form.py
@@ -287,7 +287,7 @@ def bulk_delete_form(
             col(Form.id).in_(form_ids),
             Form.organization_id == current_user.organization_id,
         )
-        .options(selectinload(Form.tests), selectinload(Form.fields))  # type: ignore[arg-type]
+        .options(selectinload(Form.tests))  # type: ignore[arg-type]
     ).all()
 
     found_ids = {form.id for form in db_forms}

--- a/backend/app/models/form.py
+++ b/backend/app/models/form.py
@@ -100,7 +100,7 @@ class Form(FormBase, table=True):
     # Relationships
     fields: list["FormField"] = Relationship(
         back_populates="form",
-        sa_relationship_kwargs={"order_by": "FormField.order", "passive_deletes": True},
+        sa_relationship_kwargs={"order_by": "FormField.order"},
     )
     tests: list["Test"] = Relationship(back_populates="form")
     organization: "Organization" = Relationship(back_populates="forms")

--- a/backend/app/models/form.py
+++ b/backend/app/models/form.py
@@ -100,7 +100,7 @@ class Form(FormBase, table=True):
     # Relationships
     fields: list["FormField"] = Relationship(
         back_populates="form",
-        sa_relationship_kwargs={"order_by": "FormField.order"},
+        sa_relationship_kwargs={"order_by": "FormField.order", "passive_deletes": True},
     )
     tests: list["Test"] = Relationship(back_populates="form")
     organization: "Organization" = Relationship(back_populates="forms")

--- a/backend/app/models/form.py
+++ b/backend/app/models/form.py
@@ -288,3 +288,8 @@ class FormResponsePublic(FormResponseBase):
     candidate_test_id: int
     form_id: int
     created_date: datetime
+
+
+class DeleteForm(SQLModel):
+    delete_success_count: int
+    delete_failure_list: list[FormPublic] | None = None

--- a/backend/app/tests/api/routes/test_form.py
+++ b/backend/app/tests/api/routes/test_form.py
@@ -193,6 +193,33 @@ def test_delete_form(
     assert get_response.status_code == 404
 
 
+def test_delete_form_with_fields_fails(
+    client: TestClient, get_user_superadmin_token: dict[str, str]
+) -> None:
+    form_response = client.post(
+        f"{settings.API_V1_STR}/form/",
+        json={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    form_id = form_response.json()["id"]
+
+    client.post(
+        f"{settings.API_V1_STR}/form/{form_id}/field/",
+        json={"field_type": "text", "label": "Name", "name": "name"},
+        headers=get_user_superadmin_token,
+    )
+
+    response = client.delete(
+        f"{settings.API_V1_STR}/form/{form_id}",
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "This form cannot be deleted while it has associated fields. "
+        "Please remove all fields before deleting the form."
+    )
+
+
 def test_bulk_delete_forms_success(
     client: TestClient, get_user_superadmin_token: dict[str, str]
 ) -> None:

--- a/backend/app/tests/api/routes/test_form.py
+++ b/backend/app/tests/api/routes/test_form.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 from app.api.deps import SessionDep
 from app.core.certificate_token import FIXED_TOKENS
 from app.core.config import settings
+from app.models.candidate import Candidate, CandidateTest
 from app.models.form import FormResponse
 from app.models.test import Test
 from app.tests.api.routes.test_tag import setup_user_organization
@@ -190,6 +191,161 @@ def test_delete_form(
         headers=get_user_superadmin_token,
     )
     assert get_response.status_code == 404
+
+
+def test_bulk_delete_forms_success(
+    client: TestClient, get_user_superadmin_token: dict[str, str]
+) -> None:
+    form_a_response = client.post(
+        f"{settings.API_V1_STR}/form/",
+        json={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    form_b_response = client.post(
+        f"{settings.API_V1_STR}/form/",
+        json={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    form_a_id = form_a_response.json()["id"]
+    form_b_id = form_b_response.json()["id"]
+
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/form/",
+        json=[form_a_id, form_b_id],
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["delete_success_count"] == 2
+    assert data["delete_failure_list"] is None
+
+
+def test_bulk_delete_forms_blocked_by_associated_test(
+    client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
+) -> None:
+    user_data = get_current_user_data(client, get_user_superadmin_token)
+    user_id = user_data["id"]
+    organization_id = user_data["organization_id"]
+
+    free_form_response = client.post(
+        f"{settings.API_V1_STR}/form/",
+        json={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    linked_form_response = client.post(
+        f"{settings.API_V1_STR}/form/",
+        json={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    free_form_id = free_form_response.json()["id"]
+    linked_form_id = linked_form_response.json()["id"]
+
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user_id,
+        organization_id=organization_id,
+        form_id=linked_form_id,
+    )
+    db.add(test)
+    db.commit()
+
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/form/",
+        json=[free_form_id, linked_form_id],
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["delete_success_count"] == 1
+    assert data["delete_failure_list"] is not None
+    assert len(data["delete_failure_list"]) == 1
+    assert data["delete_failure_list"][0]["id"] == linked_form_id
+
+
+def test_bulk_delete_forms_blocked_by_responses(
+    client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
+) -> None:
+    user_data = get_current_user_data(client, get_user_superadmin_token)
+    user_id = user_data["id"]
+    organization_id = user_data["organization_id"]
+
+    free_form_response = client.post(
+        f"{settings.API_V1_STR}/form/",
+        json={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    form_with_responses_response = client.post(
+        f"{settings.API_V1_STR}/form/",
+        json={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    free_form_id = free_form_response.json()["id"]
+    form_with_responses_id = form_with_responses_response.json()["id"]
+
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user_id,
+        organization_id=organization_id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+
+    candidate = Candidate()
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    candidate_test = CandidateTest(
+        test_id=test.id,
+        candidate_id=candidate.id,
+        admin_id=user_id,
+        device=random_lower_string(),
+        start_time="2025-01-01T10:00:00",
+    )
+    db.add(candidate_test)
+    db.commit()
+    db.refresh(candidate_test)
+
+    form_response = FormResponse(
+        form_id=form_with_responses_id,
+        candidate_test_id=candidate_test.id,
+        responses={},
+    )
+    db.add(form_response)
+    db.commit()
+
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/form/",
+        json=[free_form_id, form_with_responses_id],
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["delete_success_count"] == 1
+    assert data["delete_failure_list"] is not None
+    assert data["delete_failure_list"][0]["id"] == form_with_responses_id
+
+
+def test_bulk_delete_forms_missing_ids_returns_404(
+    client: TestClient, get_user_superadmin_token: dict[str, str]
+) -> None:
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/form/",
+        json=[-1, -2],
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+
+    assert response.status_code == 404
+    assert "invalid" in data["detail"].lower()
 
 
 # ============== Form Field Tests ==============


### PR DESCRIPTION
…ponses

## Summary

Fixes issue: #507 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk delete for forms: delete multiple forms at once. Response reports number of successful deletions and optionally lists forms that couldn't be deleted (blocked due to linked fields, tests, or existing responses).

* **Tests**
  * Added API tests covering single-form deletion constraints, successful bulk deletes, blocking when forms have associated tests/fields/responses, and 404 behavior for invalid/missing IDs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-core/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->