### PR TITLE
 Allow Location-Scoped Admin to view all self-created Test irrespective of location 

### DIFF
--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -901,11 +901,13 @@ def get_test(
             )
 
             # show only tests matching users district OR tests matching users state
+            # OR tests created by the user (regardless of location)
             # general (unmapped) tests are intentionally excluded for district-scoped users
             query = query.where(
                 or_(
                     col(Test.id).in_(district_subquery),
                     col(Test.id).in_(state_subquery),
+                    Test.created_by_id == current_user.id,
                 )
             )
         else:
@@ -930,7 +932,13 @@ def get_test(
                 )
 
                 # only show tests explicitly mapped to the user's state
-                query = query.where(col(Test.id).in_(state_subquery))
+                # OR tests created by the user (regardless of location)
+                query = query.where(
+                    or_(
+                        col(Test.id).in_(state_subquery),
+                        Test.created_by_id == current_user.id,
+                    )
+                )
 
         # if no district or state assigned, show all tests (no filter applied)
 

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -1038,10 +1038,18 @@ def get_or_create_test_link(
     response_model=TestPublic,
     dependencies=[Depends(permission_dependency("read_test"))],
 )
-def get_test_by_id(test_id: int, session: SessionDep) -> TestPublic:
+def get_test_by_id(
+    test_id: int,
+    session: SessionDep,
+    current_user: CurrentUser,
+) -> TestPublic:
     test = session.get(Test, test_id)
     if not test:
         raise HTTPException(status_code=404, detail="Test is not available")
+    if test.organization_id != current_user.organization_id:
+        raise HTTPException(
+            status_code=403, detail="Not authorized to access this test"
+        )
 
     return build_test_public_response(session, test)
 

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -2,7 +2,7 @@ import uuid
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from fastapi_pagination import Page
@@ -16,7 +16,7 @@ from app.api.deps import (
     SessionDep,
     permission_dependency,
 )
-from app.api.routes.utils import get_current_time, get_current_user_location_ids
+from app.api.routes.utils import get_current_time
 from app.core.question_sets import is_sectioned_test
 from app.core.roles import state_admin, super_admin, system_admin, test_admin
 from app.core.sorting import (
@@ -72,84 +72,6 @@ router = APIRouter(prefix="/test", tags=["Test"])
 # create sorting dependency
 TestSorting = create_sorting_dependency(TestSortConfig)
 TestSortingDep = Annotated[SortingParams, Depends(TestSorting)]
-
-
-def check_test_permission(
-    session: SessionDep,
-    current_user: CurrentUser,
-    test: Test,
-    *,
-    cached_user_location_ids: set[int] | None = None,
-    cached_user_location_level: Literal["state", "district"] | None = None,
-) -> None:
-    """Check if the current user has permission to modify the test.
-    A district level user can only modify tests of same district.
-    A state level user can only modify tests of same state."""
-
-    user_location_level: Literal["state", "district"] | None = None
-    user_location_ids: set[int] | None = None
-    exception_message = "State/test-admin cannot modify/delete general tests or tests outside their location."
-
-    if cached_user_location_level and cached_user_location_ids:
-        user_location_level = cached_user_location_level
-        user_location_ids = cached_user_location_ids
-    else:
-        user_location_level, user_location_ids = get_current_user_location_ids(
-            current_user
-        )
-    # If the user has no scoped locations, deny (matches “cannot modify general/out of scope”)
-    if not user_location_level or not user_location_ids:
-        raise HTTPException(
-            403,
-            exception_message,
-        )
-    test_district_ids: set[int] = set()
-
-    if user_location_level == "district":
-        district_rows = session.exec(
-            select(TestDistrict.district_id).where(TestDistrict.test_id == test.id)
-        ).all()
-        for row in district_rows:
-            district_id = row[0] if isinstance(row, tuple) else row
-            if district_id is not None:
-                test_district_ids.add(int(district_id))
-
-        district_out_of_scope = (not test_district_ids) or (
-            not test_district_ids.issubset(user_location_ids)
-        )
-        if district_out_of_scope:
-            raise HTTPException(
-                403,
-                exception_message,
-            )
-    else:
-        test_state_ids: set[int] = set()
-        state_rows = session.exec(
-            select(TestState.state_id).where(TestState.test_id == test.id)
-        ).all()
-        for row in state_rows:
-            state_id = row[0] if isinstance(row, tuple) else row
-            if state_id is not None:
-                test_state_ids.add(int(state_id))
-        # also include states derived from test districts
-        district_state_rows = session.exec(
-            select(District.state_id)
-            .join(TestDistrict)
-            .where(TestDistrict.district_id == District.id)
-            .where(TestDistrict.test_id == test.id)
-        ).all()
-        for row in district_state_rows:
-            district_state_id = row[0] if isinstance(row, tuple) else row
-            if district_state_id is not None:
-                test_state_ids.add(int(district_state_id))
-        state_out_of_scope = (not test_state_ids) or (
-            not test_state_ids.issubset(user_location_ids)
-        )
-        if state_out_of_scope:
-            raise HTTPException(
-                403,
-                exception_message,
-            )
 
 
 def check_test_ownership(
@@ -1116,17 +1038,10 @@ def get_or_create_test_link(
     response_model=TestPublic,
     dependencies=[Depends(permission_dependency("read_test"))],
 )
-def get_test_by_id(
-    test_id: int, session: SessionDep, current_user: CurrentUser
-) -> TestPublic:
+def get_test_by_id(test_id: int, session: SessionDep) -> TestPublic:
     test = session.get(Test, test_id)
     if not test:
         raise HTTPException(status_code=404, detail="Test is not available")
-
-    # check location based access for state/district admins
-    role = session.get(Role, current_user.role_id)
-    if role and role.name in (state_admin.name, test_admin.name):
-        check_test_permission(session, current_user, test)
 
     return build_test_public_response(session, test)
 
@@ -1146,7 +1061,7 @@ def update_test(
 
     if not test:
         raise HTTPException(status_code=404, detail="Test is not available")
-    role = check_test_ownership(session, current_user, test)
+    check_test_ownership(session, current_user, test)
     membership_fields = {"question_revision_ids", "question_sets"}
     membership_update_requested = bool(
         membership_fields.intersection(test_update.model_fields_set)
@@ -1161,9 +1076,6 @@ def update_test(
     else:
         question_revision_ids = []
         question_sets = []
-    if role and role.name in (state_admin.name, test_admin.name):
-        check_test_permission(session, current_user, test)
-
     if (
         "pause_timer_when_inactive" in test_update.model_fields_set
         and test_update.pause_timer_when_inactive != test.pause_timer_when_inactive
@@ -1379,9 +1291,7 @@ def delete_test(
     test = session.get(Test, test_id)
     if not test:
         raise HTTPException(status_code=404, detail="Test is not available")
-    role = check_test_ownership(session, current_user, test, action="delete")
-    if role and role.name in (state_admin.name, test_admin.name):
-        check_test_permission(session, current_user, test)
+    check_test_ownership(session, current_user, test, action="delete")
 
     if check_linked_question(session, test_id):
         raise HTTPException(
@@ -1424,26 +1334,11 @@ def bulk_delete_question(
         )
 
     role = session.get(Role, current_user.role_id)
-    admin_location_ids: set[int] | None = None
-    admin_location_level: Literal["state", "district"] | None = None
-
-    if role and role.name in (state_admin.name, test_admin.name):
-        admin_location_level, admin_location_ids = get_current_user_location_ids(
-            current_user
-        )
     for test in db_test:
         try:
             check_test_ownership(
                 session, current_user, test, action="delete", role=role
             )
-            if admin_location_ids:
-                check_test_permission(
-                    session,
-                    current_user,
-                    test,
-                    cached_user_location_ids=admin_location_ids,
-                    cached_user_location_level=admin_location_level,
-                )
 
             if test.id is not None and check_linked_question(session, test.id):
                 add_test_to_failure_list(session, test, failure_list)

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -2357,7 +2357,10 @@ def test_get_test_random_tag_count(
 def test_get_test_by_id(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    user = create_random_user(db)
+    organization_id = get_current_user_data(client, get_user_superadmin_token)[
+        "organization_id"
+    ]
+    user = create_random_user(db, organization_id=organization_id)
 
     country = Country(name=random_lower_string())
     db.add(country)
@@ -2533,6 +2536,57 @@ def test_get_test_by_id(
     assert data["tags"] == []
     assert data["states"] == []
     assert data["question_revisions"] == []
+
+
+def test_get_test_by_id_organization_restriction(
+    client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
+) -> None:
+    """
+    A user must not be able to fetch a test that belongs to a different organization,
+    even if they know the test ID.
+    """
+    user_data = get_current_user_data(client, get_user_superadmin_token)
+    own_org_id = user_data["organization_id"]
+
+    # Test belonging to the requesting user's organization — should be accessible
+    own_org_test = Test(
+        name=random_lower_string(),
+        link=random_lower_string(),
+        no_of_random_questions=1,
+        question_pagination=1,
+        created_by_id=user_data["id"],
+        organization_id=own_org_id,
+    )
+    db.add(own_org_test)
+
+    # Test belonging to a completely different organization — should be blocked
+    other_org = create_random_organization(db)
+    other_user = create_random_user(db, organization_id=other_org.id)
+    other_org_test = Test(
+        name=random_lower_string(),
+        link=random_lower_string(),
+        no_of_random_questions=1,
+        question_pagination=1,
+        created_by_id=other_user.id,
+        organization_id=other_org.id,
+    )
+    db.add(other_org_test)
+    db.commit()
+
+    # Can fetch a test from own organization
+    own_response = client.get(
+        f"{settings.API_V1_STR}/test/{own_org_test.id}",
+        headers=get_user_superadmin_token,
+    )
+    assert own_response.status_code == 200
+    assert own_response.json()["id"] == own_org_test.id
+
+    # Cannot fetch a test from a different organization
+    other_response = client.get(
+        f"{settings.API_V1_STR}/test/{other_org_test.id}",
+        headers=get_user_superadmin_token,
+    )
+    assert other_response.status_code == 403
 
 
 def test_update_test(
@@ -3001,7 +3055,10 @@ def test_visibility_test(
 def test_visibility_test_with_random_tag_count(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    user = create_random_user(db)
+    organization_id = get_current_user_data(client, get_user_superadmin_token)[
+        "organization_id"
+    ]
+    user = create_random_user(db, organization_id=organization_id)
     tag1 = create_random_tag(db)
     tag2 = create_random_tag(db)
 
@@ -3018,6 +3075,7 @@ def test_visibility_test_with_random_tag_count(
         question_pagination=1,
         is_template=False,
         created_by_id=user.id,
+        organization_id=organization_id,
         random_tag_count=[
             {"tag_id": tag1.id, "count": 3},
             {"tag_id": tag2.id, "count": 2},

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -7271,7 +7271,7 @@ def test_state_admin_cannot_see_state_and_district_test(
     assert state_and_district_test.id not in item_ids
 
 
-def test_state_admin_cannot_delete_general_test(
+def test_state_admin_can_delete_test_created_by_them(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
     state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
@@ -7336,8 +7336,7 @@ def test_state_admin_cannot_delete_general_test(
         f"{settings.API_V1_STR}/test/{test_id}",
         headers=token_headers,
     )
-    assert delete_resp.status_code == 403
-    assert "cannot modify/delete" in delete_resp.json()["detail"].lower()
+    assert delete_resp.status_code == 200
 
 
 def test_state_admin_can_delete_test_in_their_state(
@@ -7461,19 +7460,12 @@ def test_state_admin_cannot_delete_test_outside_their_state(
     )
     test_id = response.json()["id"]
 
-    state_admin_user = get_current_user_data(client, token_headers)
-    test_obj = db.get(Test, test_id)
-    assert test_obj is not None
-    test_obj.created_by_id = state_admin_user["id"]
-    db.add(test_obj)
-    db.commit()
-
     delete_resp = client.delete(
         f"{settings.API_V1_STR}/test/{test_id}",
         headers=token_headers,
     )
     assert delete_resp.status_code == 403
-    assert "cannot modify/delete" in delete_resp.json()["detail"].lower()
+    assert delete_resp.json()["detail"] == "You can only delete tests created by you."
 
 
 def test_state_admin_cannot_delete_multi_state_test_without_full_access(
@@ -7529,21 +7521,12 @@ def test_state_admin_cannot_delete_multi_state_test_without_full_access(
         headers=get_user_superadmin_token,
     )
     test_id = response.json()["id"]
-
-    state_admin_user = get_current_user_data(client, token_headers)
-
-    test_obj = db.get(Test, test_id)
-    assert test_obj is not None
-    test_obj.created_by_id = state_admin_user["id"]
-    db.add(test_obj)
-    db.commit()
-
     delete_resp = client.delete(
         f"{settings.API_V1_STR}/test/{test_id}",
         headers=token_headers,
     )
     assert delete_resp.status_code == 403
-    assert "cannot modify/delete" in delete_resp.json()["detail"].lower()
+    assert delete_resp.json()["detail"] == "You can only delete tests created by you."
 
 
 def test_state_admin_can_delete_test_connected_via_district(
@@ -7621,7 +7604,7 @@ def test_state_admin_can_delete_test_connected_via_district(
     assert "deleted successfully" in delete_resp.json()["message"].lower()
 
 
-def test_state_admin_cannot_delete_multi_district_test_when_only_one_state_matches(
+def test_state_admin_cannot_delete_multi_district_test_unless_self_created(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
     state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
@@ -7690,20 +7673,13 @@ def test_state_admin_cannot_delete_multi_district_test_when_only_one_state_match
     )
     test_id = response.json()["id"]
 
-    state_admin_user = get_current_user_data(client, token_headers)
-    test_obj = db.get(Test, test_id)
-    assert test_obj is not None
-    test_obj.created_by_id = state_admin_user["id"]
-    db.add(test_obj)
-    db.commit()
-
     delete_resp = client.delete(
         f"{settings.API_V1_STR}/test/{test_id}",
         headers=token_headers,
     )
 
     assert delete_resp.status_code == 403
-    assert "cannot modify/delete" in delete_resp.json()["detail"].lower()
+    assert delete_resp.json()["detail"] == "You can only delete tests created by you."
 
 
 def test_localization_list(
@@ -8118,15 +8094,6 @@ def test_district_user_cannot_modify_out_of_scope_test(
     assert data["districts"] is not None
     test_id = data["id"]
 
-    # Reassign ownership to state_admin so ownership check passes;
-    # the location check then fires because district_2 is outside their scope.
-    state_admin_user = get_current_user_data(client, token_headers)
-    test_obj = db.get(Test, test_id)
-    assert test_obj is not None
-    test_obj.created_by_id = state_admin_user["id"]
-    db.add(test_obj)
-    db.commit()
-
     response = client.put(
         f"{settings.API_V1_STR}/test/{test_id}",
         headers=token_headers,
@@ -8135,7 +8102,7 @@ def test_district_user_cannot_modify_out_of_scope_test(
 
     assert response.status_code == 403
     data = response.json()
-    assert "cannot modify/delete" in data["detail"]
+    assert data["detail"] == "You can only update tests created by you."
 
     response = client.delete(
         f"{settings.API_V1_STR}/test/{test_id}",
@@ -8144,7 +8111,7 @@ def test_district_user_cannot_modify_out_of_scope_test(
 
     assert response.status_code == 403
     data = response.json()
-    assert "cannot modify/delete" in data["detail"]
+    assert data["detail"] == "You can only delete tests created by you."
 
 
 def test_get_tests_by_district_user(

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -9821,3 +9821,208 @@ def test_get_tests_my_tests_filter_no_location_user(
     assert my_test_2.id not in returned_ids
     assert other_test_1.id in returned_ids
     assert other_test_2.id in returned_ids
+
+
+def test_state_admin_can_see_tests_they_created_outside_their_location(
+    client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
+) -> None:
+    """
+    A state_admin scoped to state_A should see tests they personally created
+    even if those tests are mapped to state_B (outside their location scope).
+    """
+    new_organization = create_random_organization(db)
+    db.add(new_organization)
+    db.commit()
+
+    country = Country(name=random_lower_string(), is_active=True)
+    db.add(country)
+    db.commit()
+    db.refresh(country)
+
+    state_a = State(name=random_lower_string(), is_active=True, country_id=country.id)
+    state_b = State(name=random_lower_string(), is_active=True, country_id=country.id)
+    db.add_all([state_a, state_b])
+    db.commit()
+    db.refresh(state_a)
+    db.refresh(state_b)
+
+    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
+    assert state_admin_role is not None
+    state_admin_email = random_email()
+    client.post(
+        f"{settings.API_V1_STR}/users/",
+        json={
+            "email": state_admin_email,
+            "password": random_lower_string(),
+            "phone": random_lower_string(),
+            "full_name": random_lower_string(),
+            "role_id": state_admin_role.id,
+            "organization_id": new_organization.id,
+            "state_ids": [state_a.id],
+        },
+        headers=get_user_superadmin_token,
+    )
+    state_admin_token = authentication_token_from_email(
+        client=client, email=state_admin_email, db=db
+    )
+
+    # state_admin creates a test mapped to state_B (outside their own state_A scope)
+    outside_test_resp = client.post(
+        f"{settings.API_V1_STR}/test/",
+        json={
+            "name": random_lower_string(),
+            "time_limit": 30,
+            "marks": 10,
+            "link": random_lower_string(),
+            "state_ids": [state_b.id],
+        },
+        headers=state_admin_token,
+    )
+    assert outside_test_resp.status_code == 200
+    outside_test_id = outside_test_resp.json()["id"]
+
+    # state_admin creates a test mapped to their own state_A (within scope)
+    in_scope_test_resp = client.post(
+        f"{settings.API_V1_STR}/test/",
+        json={
+            "name": random_lower_string(),
+            "time_limit": 30,
+            "marks": 10,
+            "link": random_lower_string(),
+            "state_ids": [state_a.id],
+        },
+        headers=state_admin_token,
+    )
+    assert in_scope_test_resp.status_code == 200
+    in_scope_test_id = in_scope_test_resp.json()["id"]
+
+    response = client.get(f"{settings.API_V1_STR}/test/", headers=state_admin_token)
+    assert response.status_code == 200
+    returned_ids = {item["id"] for item in response.json()["items"]}
+
+    # Both tests must be visible: in-scope by location, out-of-scope because created by them
+    assert in_scope_test_id in returned_ids
+    assert outside_test_id in returned_ids
+
+    # my_tests=true: both tests are visible because the state_admin created them
+    my_tests_response = client.get(
+        f"{settings.API_V1_STR}/test/?my_tests=true", headers=state_admin_token
+    )
+    assert my_tests_response.status_code == 200
+    my_tests_ids = {item["id"] for item in my_tests_response.json()["items"]}
+    assert in_scope_test_id in my_tests_ids
+    assert outside_test_id in my_tests_ids
+
+    # my_tests=false: neither test is visible because both were created by the state_admin
+    not_my_tests_response = client.get(
+        f"{settings.API_V1_STR}/test/?my_tests=false", headers=state_admin_token
+    )
+    assert not_my_tests_response.status_code == 200
+    not_my_tests_ids = {item["id"] for item in not_my_tests_response.json()["items"]}
+    assert in_scope_test_id not in not_my_tests_ids
+    assert outside_test_id not in not_my_tests_ids
+
+
+def test_test_admin_can_see_tests_they_created_outside_their_district(
+    client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
+) -> None:
+    """
+    A test_admin scoped to district_A should see tests they personally created
+    even if those tests are mapped to district_B (outside their location scope).
+    """
+    new_organization = create_random_organization(db)
+    db.add(new_organization)
+    db.commit()
+
+    country = Country(name=random_lower_string(), is_active=True)
+    db.add(country)
+    db.commit()
+    db.refresh(country)
+
+    state = State(name=random_lower_string(), is_active=True, country_id=country.id)
+    db.add(state)
+    db.commit()
+    db.refresh(state)
+
+    district_a = District(name=random_lower_string(), is_active=True, state_id=state.id)
+    district_b = District(name=random_lower_string(), is_active=True, state_id=state.id)
+    db.add_all([district_a, district_b])
+    db.commit()
+    db.refresh(district_a)
+    db.refresh(district_b)
+
+    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
+    assert test_admin_role is not None
+    test_admin_email = random_email()
+    client.post(
+        f"{settings.API_V1_STR}/users/",
+        json={
+            "email": test_admin_email,
+            "password": random_lower_string(),
+            "phone": random_lower_string(),
+            "full_name": random_lower_string(),
+            "role_id": test_admin_role.id,
+            "organization_id": new_organization.id,
+            "district_ids": [district_a.id],
+        },
+        headers=get_user_superadmin_token,
+    )
+    test_admin_token = authentication_token_from_email(
+        client=client, email=test_admin_email, db=db
+    )
+
+    # test_admin creates a test mapped to district_B (outside their district_A scope)
+    outside_test_resp = client.post(
+        f"{settings.API_V1_STR}/test/",
+        json={
+            "name": random_lower_string(),
+            "time_limit": 30,
+            "marks": 10,
+            "link": random_lower_string(),
+            "district_ids": [district_b.id],
+        },
+        headers=test_admin_token,
+    )
+    assert outside_test_resp.status_code == 200
+    outside_test_id = outside_test_resp.json()["id"]
+
+    # test_admin creates a test mapped to their own district_A (within scope)
+    in_scope_test_resp = client.post(
+        f"{settings.API_V1_STR}/test/",
+        json={
+            "name": random_lower_string(),
+            "time_limit": 30,
+            "marks": 10,
+            "link": random_lower_string(),
+            "district_ids": [district_a.id],
+        },
+        headers=test_admin_token,
+    )
+    assert in_scope_test_resp.status_code == 200
+    in_scope_test_id = in_scope_test_resp.json()["id"]
+
+    response = client.get(f"{settings.API_V1_STR}/test/", headers=test_admin_token)
+    assert response.status_code == 200
+    returned_ids = {item["id"] for item in response.json()["items"]}
+
+    # Both tests must be visible: in-scope by location, out-of-scope because created by them
+    assert in_scope_test_id in returned_ids
+    assert outside_test_id in returned_ids
+
+    # my_tests=true: both tests are visible because the test_admin created them
+    my_tests_response = client.get(
+        f"{settings.API_V1_STR}/test/?my_tests=true", headers=test_admin_token
+    )
+    assert my_tests_response.status_code == 200
+    my_tests_ids = {item["id"] for item in my_tests_response.json()["items"]}
+    assert in_scope_test_id in my_tests_ids
+    assert outside_test_id in my_tests_ids
+
+    # my_tests=false: neither test is visible because both were created by the test_admin
+    not_my_tests_response = client.get(
+        f"{settings.API_V1_STR}/test/?my_tests=false", headers=test_admin_token
+    )
+    assert not_my_tests_response.status_code == 200
+    not_my_tests_ids = {item["id"] for item in not_my_tests_response.json()["items"]}
+    assert in_scope_test_id not in not_my_tests_ids
+    assert outside_test_id not in not_my_tests_ids


### PR DESCRIPTION
## Summary

Fixes: #502 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated test permission model to enforce ownership-based access instead of location-based restrictions.
  * Users can now view and manage tests they created, regardless of location mapping.
  * Refined authorization error messages for test modifications and deletions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-core/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->