### PR TITLE
Add Avanti external login with candidate reuse

### DIFF
--- a/backend/app/alembic/versions/8d7a2c9f1b34_add_external_login_to_organization_settings.py
+++ b/backend/app/alembic/versions/8d7a2c9f1b34_add_external_login_to_organization_settings.py
@@ -1,0 +1,50 @@
+"""add external_login to organization settings
+
+Revision ID: 8d7a2c9f1b34
+Revises: 6f5c1d64e010
+Create Date: 2026-05-28 00:00:00.000000
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8d7a2c9f1b34"
+down_revision: str = "6f5c1d64e010"
+branch_labels = None
+depends_on = None
+
+# Frozen default — do not reference live model constants.
+_FROZEN_EXTERNAL_LOGIN_DEFAULT = {
+    "mode": "fixed",
+    "value": {
+        "enabled": False,
+        "block_anonymous_starts": False,
+    },
+}
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE organization_settings
+            SET settings = settings
+                || jsonb_build_object('external_login', CAST(:external_login AS JSONB))
+                || jsonb_build_object('version', 6)
+            """
+        ).bindparams(external_login=json.dumps(_FROZEN_EXTERNAL_LOGIN_DEFAULT))
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE organization_settings
+        SET settings = (settings - 'external_login')
+            || jsonb_build_object('version', 5)
+        """
+    )

--- a/backend/app/alembic/versions/a1e4c7b2f9d0_add_external_user_id_to_candidate.py
+++ b/backend/app/alembic/versions/a1e4c7b2f9d0_add_external_user_id_to_candidate.py
@@ -1,0 +1,45 @@
+"""Add external_user_id to candidate for external-login candidate reuse
+
+Revision ID: a1e4c7b2f9d0
+Revises: 8d7a2c9f1b34
+Create Date: 2026-07-10 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1e4c7b2f9d0'
+down_revision = '8d7a2c9f1b34'
+branch_labels = None
+depends_on = None
+
+
+# Reuse a single candidate per (organization, external user). Anonymous QR
+# candidates keep external_user_id NULL, so the partial index leaves them alone.
+UNIQUE_INDEX_NAME = "uq_candidate_org_external_user_id"
+
+
+def upgrade():
+    op.add_column(
+        'candidate',
+        sa.Column(
+            'external_user_id',
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        UNIQUE_INDEX_NAME,
+        'candidate',
+        ['organization_id', 'external_user_id'],
+        unique=True,
+        postgresql_where=sa.text('external_user_id IS NOT NULL'),
+    )
+
+
+def downgrade():
+    op.drop_index(UNIQUE_INDEX_NAME, table_name='candidate')
+    op.drop_column('candidate', 'external_user_id')

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -60,7 +60,6 @@ from app.models.candidate import (
     CandidateTimerSyncRequest,
     DeleteCandidate,
     ExternalProvisionRequest,
-    ExternalStartRequest,
     OverallTestAnalyticsResponse,
     Result,
     StartTestRequest,
@@ -949,18 +948,59 @@ def _require_external_login_enabled(session: SessionDep, test: Test) -> None:
         )
 
 
+def _get_candidate_test_by_uuid(
+    session: SessionDep, test: Test, candidate_uuid: uuid.UUID
+) -> CandidateTest:
+    """Resume a previously provisioned attempt for this test.
+
+    Scoping by test_id plus the unguessable candidate identity is sufficient
+    authorization here, so unlike verify_candidate_uuid_access this does not
+    also need the candidate_test_id as a second factor.
+    """
+    candidate_test = session.exec(
+        select(CandidateTest)
+        .join(Candidate)
+        .where(CandidateTest.test_id == test.id)
+        .where(Candidate.identity == candidate_uuid)
+    ).first()
+    if not candidate_test:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Candidate test not found or invalid UUID",
+        )
+    return candidate_test
+
+
 @router.post("/start_test", response_model=StartTestResponse)
 def start_test_for_candidate(
     session: SessionDep,
     start_test_request: StartTestRequest = Body(...),
+    candidate_uuid: uuid.UUID | None = Query(
+        default=None,
+        description="Resume a previously provisioned externally-mapped attempt",
+    ),
 ) -> StartTestResponse:
     """
     Creates a candidate when they start a test, links them to the test.
     Returns the candidate UUID for verification.
+
+    If candidate_uuid is provided, resumes an existing externally-provisioned
+    attempt (see /external/provision) instead of creating a new anonymous one.
     """
     test, admin_id = _resolve_active_test_link(
         session, start_test_request.test_link_uuid
     )
+
+    if candidate_uuid is not None:
+        _require_external_login_enabled(session, test)
+        _validate_test_start_window(session, test)
+        candidate_test = _get_candidate_test_by_uuid(session, test, candidate_uuid)
+        return StartTestResponse(
+            candidate_uuid=candidate_uuid,
+            candidate_test_id=candidate_test.id,
+            is_submitted=candidate_test.is_submitted,
+        )
+
     if _should_block_anonymous_start(session, test):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -988,7 +1028,7 @@ def provision_external_candidate_test(
     current_user: CurrentUser,
     provision_request: ExternalProvisionRequest = Body(...),
 ) -> StartTestResponse:
-    """Create the Sashakt candidate and attempt Avanti will map to its user."""
+    """Create the Sashakt candidate and attempt Organization will map to its user."""
     test, admin_id = _resolve_active_test_link(
         session, provision_request.test_link_uuid
     )
@@ -1013,32 +1053,6 @@ def provision_external_candidate_test(
     return StartTestResponse(
         candidate_uuid=candidate.identity,
         candidate_test_id=candidate_test.id,
-        is_submitted=candidate_test.is_submitted,
-    )
-
-
-@router.post("/external/start_test", response_model=StartTestResponse)
-def start_external_candidate_test(
-    session: SessionDep,
-    start_request: ExternalStartRequest = Body(...),
-) -> StartTestResponse:
-    """Resume an externally provisioned attempt using Sashakt-owned IDs."""
-    test, _admin_id = _resolve_active_test_link(session, start_request.test_link_uuid)
-    _require_external_login_enabled(session, test)
-    _validate_test_start_window(session, test)
-
-    candidate_test = verify_candidate_uuid_access(
-        session, start_request.candidate_test_id, start_request.candidate_uuid
-    )
-    if candidate_test.test_id != test.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Candidate test not found for this test link",
-        )
-
-    return StartTestResponse(
-        candidate_uuid=start_request.candidate_uuid,
-        candidate_test_id=start_request.candidate_test_id,
         is_submitted=candidate_test.is_submitted,
     )
 

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta
 from typing import Any
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from sqlmodel import and_, col, not_, select
 
 from app.api.deps import CurrentUser, SessionDep, permission_dependency
@@ -59,6 +59,8 @@ from app.models.candidate import (
     CandidateTimerEventType,
     CandidateTimerSyncRequest,
     DeleteCandidate,
+    ExternalProvisionRequest,
+    ExternalStartRequest,
     OverallTestAnalyticsResponse,
     Result,
     StartTestRequest,
@@ -674,26 +676,54 @@ def get_overall_tests_analytics(
     )
 
 
-@router.post("/start_test", response_model=StartTestResponse)
-def start_test_for_candidate(
-    session: SessionDep,
-    start_test_request: StartTestRequest = Body(...),
-) -> StartTestResponse:
-    """
-    Creates a candidate when they start a test, links them to the test.
-    Returns the candidate UUID for verification.
-    """
-    # Resolve test and admin from the UUID — TestLink takes precedence over legacy Test.link
+def _resolve_active_test_link(
+    session: SessionDep, test_link_uuid: str
+) -> tuple[Test, int]:
     test_link = session.exec(
-        select(TestLink).where(TestLink.uuid == start_test_request.test_link_uuid)
+        select(TestLink).where(TestLink.uuid == test_link_uuid)
     ).first()
-    if test_link:
-        test = session.get(Test, test_link.test_id)
-        admin_id: int = test_link.created_by_id
-    else:
+    if not test_link:
         raise HTTPException(status_code=404, detail="Test Link Not Found")
+
+    test = session.get(Test, test_link.test_id)
     if not test or (test.is_active is False):
         raise HTTPException(status_code=404, detail="Test not found or not active")
+    return test, test_link.created_by_id
+
+
+def _validate_test_start_window(session: SessionDep, test: Test) -> None:
+    current_time = get_current_time()
+    if test.start_time and test.start_time > current_time:
+        raise HTTPException(
+            status_code=400,
+            detail="Test has not started yet. Please wait until the scheduled start time.",
+        )
+
+    if test.organization_id is None:
+        return
+
+    settings_payload = crud_settings.get_payload(
+        session=session, organization_id=test.organization_id
+    )
+    if settings_payload is None:
+        return
+
+    outside_window = check_org_time_window(settings_payload, current_time)
+    if outside_window is not None:
+        window_start, window_end = outside_window
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Tests can only be started between "
+                f"{window_start.strftime('%H:%M')} and "
+                f"{window_end.strftime('%H:%M')}."
+            ),
+        )
+
+
+def _build_assigned_question_ids(
+    session: SessionDep, test: Test
+) -> tuple[list[int], list[int | None]]:
     test_id = get_persisted_test_id(test)
     test_questions = get_test_question_links(session, test_id)
     question_sets = get_test_question_sets(session, test_id)
@@ -777,49 +807,28 @@ def start_test_for_candidate(
         ]
         question_set_ids = [question_set_id for _, question_set_id in combined]
 
-    current_time = get_current_time()
-    if test.start_time and test.start_time > current_time:
-        raise HTTPException(
-            status_code=400,
-            detail="Test has not started yet. Please wait until the scheduled start time.",
-        )
+    return question_revision_ids, question_set_ids
 
-    if test.organization_id is not None:
-        settings_payload = crud_settings.get_payload(
-            session=session, organization_id=test.organization_id
-        )
-        if settings_payload is not None:
-            outside_window = check_org_time_window(settings_payload, current_time)
-            if outside_window is not None:
-                window_start, window_end = outside_window
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "Tests can only be started between "
-                        f"{window_start.strftime('%H:%M')} and "
-                        f"{window_end.strftime('%H:%M')}."
-                    ),
-                )
 
-    # Create a new anonymous candidate with UUID
-    candidate = Candidate(
-        identity=uuid.uuid4(),  # Generate UUID for anonymous candidate
-        organization_id=test.organization_id,
+def _create_candidate_test(
+    session: SessionDep,
+    *,
+    test: Test,
+    candidate: Candidate,
+    admin_id: int,
+    start_test_request: StartTestRequest,
+) -> CandidateTest:
+    question_revision_ids, question_set_ids = _build_assigned_question_ids(
+        session, test
     )
-    session.add(candidate)
-    session.flush()  # assigns candidate.id without committing
-
-    # Set start_time when test begins, end_time will be set when test is submitted
     start_time = get_current_time()
-
-    # Create CandidateTest link
     candidate_test = CandidateTest(
         test_id=test.id,
         candidate_id=candidate.id,
         device=start_test_request.device_info or "unknown",
         consent=True,
         start_time=start_time,
-        end_time=None,  # Will be set when test is actually submitted
+        end_time=None,
         is_submitted=False,
         question_revision_ids=question_revision_ids,
         question_set_ids=question_set_ids,
@@ -831,7 +840,6 @@ def start_test_for_candidate(
     session.add(candidate_test)
     session.flush()  # assigns candidate_test.id without committing
 
-    # Handle form responses
     if start_test_request.form_responses and test.form_id:
         form_response = FormResponse(
             candidate_test_id=candidate_test.id,
@@ -842,9 +850,196 @@ def start_test_for_candidate(
 
     session.commit()  # single commit for candidate, candidate_test, and form_response
 
+    return candidate_test
+
+
+def _create_anonymous_candidate(session: SessionDep, test: Test) -> Candidate:
+    candidate = Candidate(
+        identity=uuid.uuid4(),
+        organization_id=test.organization_id,
+    )
+    session.add(candidate)
+    session.flush()  # assigns candidate.id without committing; committed with the test
+    return candidate
+
+
+def _get_or_create_external_candidate(
+    session: SessionDep, test: Test, external_user_id: str
+) -> Candidate:
+    """Reuse a single candidate per (organization, external_user_id).
+
+    Unlike anonymous QR candidates (a fresh row per start), an external user is a
+    recurring student: the same candidate is returned across all their tests.
+    """
+    candidate = session.exec(
+        select(Candidate)
+        .where(Candidate.organization_id == test.organization_id)
+        .where(Candidate.external_user_id == external_user_id)
+    ).first()
+    if candidate is not None:
+        return candidate
+
+    candidate = Candidate(
+        identity=uuid.uuid4(),
+        organization_id=test.organization_id,
+        external_user_id=external_user_id,
+    )
+    session.add(candidate)
+    session.flush()  # assigns candidate.id without committing; committed with the test
+    return candidate
+
+
+def _get_or_create_candidate_test(
+    session: SessionDep,
+    *,
+    test: Test,
+    candidate: Candidate,
+    admin_id: int,
+    start_test_request: StartTestRequest,
+) -> CandidateTest:
+    """Find the candidate's existing attempt for this test, or create one.
+
+    A reused candidate may already have a CandidateTest for this test (the
+    UNIQUE(test_id, candidate_id) constraint enforces one attempt per pair), so
+    re-provisioning must be idempotent rather than raising a unique violation.
+    """
+    existing = session.exec(
+        select(CandidateTest)
+        .where(CandidateTest.test_id == test.id)
+        .where(CandidateTest.candidate_id == candidate.id)
+    ).first()
+    if existing is not None:
+        return existing
+
+    return _create_candidate_test(
+        session,
+        test=test,
+        candidate=candidate,
+        admin_id=admin_id,
+        start_test_request=start_test_request,
+    )
+
+
+def _get_external_login_value(session: SessionDep, test: Test) -> Any | None:
+    if test.organization_id is None:
+        return None
+    settings_payload = crud_settings.get_payload(
+        session=session, organization_id=test.organization_id
+    )
+    if settings_payload is None:
+        return None
+    return settings_payload.external_login.value
+
+
+def _should_block_anonymous_start(session: SessionDep, test: Test) -> bool:
+    external_login = _get_external_login_value(session, test)
+    return bool(
+        external_login
+        and external_login.enabled
+        and external_login.block_anonymous_starts
+    )
+
+
+def _require_external_login_enabled(session: SessionDep, test: Test) -> None:
+    external_login = _get_external_login_value(session, test)
+    if external_login is None or not external_login.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="External login is not enabled for this organization",
+        )
+
+
+@router.post("/start_test", response_model=StartTestResponse)
+def start_test_for_candidate(
+    session: SessionDep,
+    start_test_request: StartTestRequest = Body(...),
+) -> StartTestResponse:
+    """
+    Creates a candidate when they start a test, links them to the test.
+    Returns the candidate UUID for verification.
+    """
+    test, admin_id = _resolve_active_test_link(
+        session, start_test_request.test_link_uuid
+    )
+    if _should_block_anonymous_start(session, test):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Please open this test from your student portal.",
+        )
+    _validate_test_start_window(session, test)
+    candidate = _create_anonymous_candidate(session, test)
+    candidate_test = _create_candidate_test(
+        session,
+        test=test,
+        candidate=candidate,
+        admin_id=admin_id,
+        start_test_request=start_test_request,
+    )
+
     return StartTestResponse(
         candidate_uuid=candidate.identity,
         candidate_test_id=candidate_test.id,
+    )
+
+
+@router.post("/external/provision", response_model=StartTestResponse)
+def provision_external_candidate_test(
+    session: SessionDep,
+    current_user: CurrentUser,
+    provision_request: ExternalProvisionRequest = Body(...),
+) -> StartTestResponse:
+    """Create the Sashakt candidate and attempt Avanti will map to its user."""
+    test, admin_id = _resolve_active_test_link(
+        session, provision_request.test_link_uuid
+    )
+    if test.organization_id != current_user.organization_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Test link not found for this organization",
+        )
+    _require_external_login_enabled(session, test)
+    _validate_test_start_window(session, test)
+
+    candidate = _get_or_create_external_candidate(
+        session, test, provision_request.external_user_id
+    )
+    candidate_test = _get_or_create_candidate_test(
+        session,
+        test=test,
+        candidate=candidate,
+        admin_id=admin_id,
+        start_test_request=provision_request,
+    )
+    return StartTestResponse(
+        candidate_uuid=candidate.identity,
+        candidate_test_id=candidate_test.id,
+        is_submitted=candidate_test.is_submitted,
+    )
+
+
+@router.post("/external/start_test", response_model=StartTestResponse)
+def start_external_candidate_test(
+    session: SessionDep,
+    start_request: ExternalStartRequest = Body(...),
+) -> StartTestResponse:
+    """Resume an externally provisioned attempt using Sashakt-owned IDs."""
+    test, _admin_id = _resolve_active_test_link(session, start_request.test_link_uuid)
+    _require_external_login_enabled(session, test)
+    _validate_test_start_window(session, test)
+
+    candidate_test = verify_candidate_uuid_access(
+        session, start_request.candidate_test_id, start_request.candidate_uuid
+    )
+    if candidate_test.test_id != test.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Candidate test not found for this test link",
+        )
+
+    return StartTestResponse(
+        candidate_uuid=start_request.candidate_uuid,
+        candidate_test_id=start_request.candidate_test_id,
+        is_submitted=candidate_test.is_submitted,
     )
 
 
@@ -887,6 +1082,9 @@ def submit_answer_for_qr_candidate(
     candidate_test = verify_candidate_uuid_access(
         session, candidate_test_id, candidate_uuid
     )
+    if candidate_test.is_submitted:
+        raise HTTPException(status_code=400, detail="Test already submitted")
+
     question_revision = session.get(
         QuestionRevision, answer_request.question_revision_id
     )
@@ -2027,6 +2225,8 @@ def compute_result(
 
     total_questions = len(candidate_test.question_revision_ids)
 
+    candidate = session.get(Candidate, candidate_test.candidate_id)
+
     return Result(
         correct_answer=correct,
         incorrect_answer=incorrect,
@@ -2035,6 +2235,7 @@ def compute_result(
         total_questions=total_questions,
         marks_obtained=marks_obtained if has_marking_scheme else None,
         marks_maximum=marks_maximum if has_marking_scheme else None,
+        external_user_id=candidate.external_user_id if candidate else None,
     )
 
 

--- a/backend/app/api/routes/organization_settings.py
+++ b/backend/app/api/routes/organization_settings.py
@@ -128,6 +128,9 @@ def update_organization_settings(
     payload.settings.platform_guide.value.file_path = (
         current_payload.platform_guide.value.file_path
     )
+    # External login is deployment-controlled for now. Preserve the DB value so
+    # older Portal clients do not accidentally reset it while saving other settings.
+    payload.settings.external_login = current_payload.external_login
 
     row = crud_settings.upsert(
         session=session,

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -358,11 +358,6 @@ class ExternalProvisionRequest(StartTestRequest):
     external_user_id: str
 
 
-class ExternalStartRequest(StartTestRequest):
-    candidate_uuid: uuid.UUID
-    candidate_test_id: int
-
-
 class OverallTestAnalyticsResponse(SQLModel):
     total_candidates: int
     overall_score_percent: float

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -228,6 +228,10 @@ class Candidate(CandidateBase, table=True):
     identity: uuid.UUID | None = Field(
         default=None, unique=True, index=True, nullable=True
     )  # Only for anonymous QR code users
+    external_user_id: str | None = Field(
+        default=None
+    )  # External (e.g. Avanti) user id; reused across tests per (organization, external_user_id).
+    # Uniqueness + lookup covered by the partial unique index in the migration.
     created_date: datetime | None = Field(default_factory=get_timezone_aware_now)
     modified_date: datetime | None = Field(
         default_factory=get_timezone_aware_now,
@@ -326,6 +330,9 @@ class Result(SQLModel):
     marks_obtained: float | None
     marks_maximum: float | None
     certificate_download_url: str | None = None
+    # External (e.g. Avanti) user id, when the candidate came via external login;
+    # None for anonymous QR candidates.
+    external_user_id: str | None = None
 
 
 class TestStatusSummary(SQLModel):
@@ -342,6 +349,16 @@ class StartTestRequest(SQLModel):
 
 
 class StartTestResponse(SQLModel):
+    candidate_uuid: uuid.UUID
+    candidate_test_id: int
+    is_submitted: bool = False
+
+
+class ExternalProvisionRequest(StartTestRequest):
+    external_user_id: str
+
+
+class ExternalStartRequest(StartTestRequest):
     candidate_uuid: uuid.UUID
     candidate_test_id: int
 

--- a/backend/app/models/organization_settings.py
+++ b/backend/app/models/organization_settings.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from app.models.organization import Organization
 
 
-ORGANIZATION_SETTINGS_SCHEMA_VERSION = 5
+ORGANIZATION_SETTINGS_SCHEMA_VERSION = 6
 
 
 NOMENCLATURE_DEFAULTS: dict[str, str] = {
@@ -185,6 +185,26 @@ class PauseTestSetting(BaseModel):
     value: PauseTestValue = PydanticField(default_factory=PauseTestValue)
 
 
+class ExternalLoginValue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    block_anonymous_starts: bool = False
+
+
+class ExternalLoginSetting(BaseModel):
+    """Organization-level external launch control.
+
+    Kept org-scoped so Sashakt Portal does not need a visible per-test option
+    for partner-only login flows.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["fixed"] = "fixed"
+    value: ExternalLoginValue = PydanticField(default_factory=ExternalLoginValue)
+
+
 class PlatformNomenclatureValue(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -325,6 +345,9 @@ class OrganizationSettingsPayload(BaseModel):
             mode="fixed", value=PauseTestValue(default=False)
         )
     )
+    external_login: ExternalLoginSetting = PydanticField(
+        default_factory=ExternalLoginSetting
+    )
     platform_nomenclature: PlatformNomenclatureSetting
     platform_guide: PlatformGuideSetting = PydanticField(
         default_factory=PlatformGuideSetting
@@ -382,6 +405,7 @@ def default_organization_settings() -> OrganizationSettingsPayload:
             mode="fixed",
             value=PauseTestValue(default=False),
         ),
+        external_login=ExternalLoginSetting(),
         platform_nomenclature=PlatformNomenclatureSetting(mode="default"),
         platform_guide=PlatformGuideSetting(),
         analytics_link=AnalyticsLinkSetting(),

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -22,6 +22,10 @@ from app.models import (
 from app.models.certificate import Certificate
 from app.models.form import Form, FormField, FormFieldType, FormResponse
 from app.models.location import Country, District, State
+from app.models.organization_settings import (
+    OrganizationSettings,
+    default_organization_settings,
+)
 from app.models.question import QuestionTag, QuestionType
 from app.models.role import Role
 from app.models.tag import Tag, TagType
@@ -91,6 +95,33 @@ def create_single_choice_question_revision(
     db.commit()
     db.refresh(revision)
     return revision
+
+
+def enable_avanti_external_login(
+    db: SessionDep, *, organization_id: int
+) -> OrganizationSettings:
+    payload = default_organization_settings()
+    payload.external_login.value.enabled = True
+    payload.external_login.value.block_anonymous_starts = True
+    payload.test_timings.value.start_time = time(0, 1)
+    payload.test_timings.value.end_time = time(23, 59)
+
+    row = db.exec(
+        select(OrganizationSettings).where(
+            OrganizationSettings.organization_id == organization_id
+        )
+    ).first()
+    if row is None:
+        row = OrganizationSettings(
+            organization_id=organization_id,
+            settings=payload.model_dump(mode="json"),
+        )
+    else:
+        row.settings = payload.model_dump(mode="json")
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
 
 
 def test_create_candidate(
@@ -2320,6 +2351,21 @@ def test_submit_answer_for_qr_candidate(client: TestClient, db: SessionDep) -> N
     ).first()
     assert answer is not None
     assert answer.response == "[1, 2]"
+
+    candidate_test = db.get(CandidateTest, candidate_test_id)
+    assert candidate_test is not None
+    candidate_test.is_submitted = True
+    db.add(candidate_test)
+    db.commit()
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/submit_answer/{candidate_test_id}",
+        json={**answer_payload, "response": "[2]"},
+        params={"candidate_uuid": candidate_uuid},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Test already submitted"
 
 
 def test_submit_answer_enforces_question_set_attempt_limit(
@@ -15685,6 +15731,498 @@ def test_start_test_stores_admin_id(client: TestClient, db: SessionDep) -> None:
     candidate_test = db.get(CandidateTest, data["candidate_test_id"])
     assert candidate_test is not None
     assert candidate_test.admin_id == user.id
+
+
+def test_start_test_rejects_anonymous_for_external_login_org(
+    client: TestClient, db: SessionDep
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        json={"test_link_uuid": test_link.uuid, "device_info": "Browser"},
+    )
+
+    assert response.status_code == 403
+    assert (
+        response.json()["detail"] == "Please open this test from your student portal."
+    )
+
+
+def test_anonymous_start_test_leaves_external_user_id_null(
+    client: TestClient, db: SessionDep
+) -> None:
+    """The QR/anonymous flow must be untouched: no external_user_id is stored."""
+    user = create_random_user(db)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        json={"test_link_uuid": test_link.uuid, "device_info": "Browser"},
+    )
+
+    assert response.status_code == 200
+    candidate_test = db.get(CandidateTest, response.json()["candidate_test_id"])
+    assert candidate_test is not None
+    candidate = db.get(Candidate, candidate_test.candidate_id)
+    assert candidate is not None
+    assert candidate.external_user_id is None
+
+
+def test_external_provision_requires_sashakt_auth(
+    client: TestClient, db: SessionDep
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={
+            "test_link_uuid": test_link.uuid,
+            "external_user_id": "375220",
+            "device_info": "Portal",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={
+            "test_link_uuid": test_link.uuid,
+            "external_user_id": "375220",
+            "device_info": "Portal",
+        },
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Could not validate credentials"
+
+
+def test_external_provision_requires_external_login_enabled(
+    client: TestClient, db: SessionDep
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+    token_headers = authentication_token_from_email(
+        client=client, email=user.email, db=db
+    )
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={
+            "test_link_uuid": test_link.uuid,
+            "external_user_id": "375220",
+            "device_info": "Portal",
+        },
+        headers=token_headers,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == (
+        "External login is not enabled for this organization"
+    )
+
+
+def test_external_provision_and_start_resume_same_attempt(
+    client: TestClient, db: SessionDep
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+    token_headers = authentication_token_from_email(
+        client=client, email=user.email, db=db
+    )
+
+    provision_response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={
+            "test_link_uuid": test_link.uuid,
+            "external_user_id": "375220",
+            "device_info": "Portal",
+        },
+        headers=token_headers,
+    )
+    assert provision_response.status_code == 200
+    provision_data = provision_response.json()
+
+    candidate_test = db.get(CandidateTest, provision_data["candidate_test_id"])
+    assert candidate_test is not None
+    assert candidate_test.test_id == test.id
+
+    start_response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/start_test",
+        json={
+            "test_link_uuid": test_link.uuid,
+            "candidate_uuid": provision_data["candidate_uuid"],
+            "candidate_test_id": provision_data["candidate_test_id"],
+            "device_info": "Mobile",
+        },
+    )
+
+    assert start_response.status_code == 200
+    assert start_response.json() == provision_data
+
+
+def test_external_start_reports_submitted_attempt(
+    client: TestClient, db: SessionDep
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+    token_headers = authentication_token_from_email(
+        client=client, email=user.email, db=db
+    )
+
+    provision_response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={
+            "test_link_uuid": test_link.uuid,
+            "external_user_id": "375220",
+            "device_info": "Portal",
+        },
+        headers=token_headers,
+    )
+    assert provision_response.status_code == 200
+    provision_data = provision_response.json()
+    assert provision_data["is_submitted"] is False
+
+    candidate_test = db.get(CandidateTest, provision_data["candidate_test_id"])
+    assert candidate_test is not None
+    candidate_test.is_submitted = True
+    db.add(candidate_test)
+    db.commit()
+
+    start_response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/start_test",
+        json={
+            "test_link_uuid": test_link.uuid,
+            "candidate_uuid": provision_data["candidate_uuid"],
+            "candidate_test_id": provision_data["candidate_test_id"],
+            "device_info": "Mobile",
+        },
+    )
+
+    assert start_response.status_code == 200
+    assert start_response.json()["is_submitted"] is True
+
+
+def test_external_provision_reuses_same_candidate_across_tests(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Same external user taking two different tests reuses one candidate."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test_a = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    test_b = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test_a)
+    db.add(test_b)
+    db.commit()
+    db.refresh(test_a)
+    db.refresh(test_b)
+    test_a_link = get_test_link(db, test_id=test_a.id, admin_id=user.id)
+    test_b_link = get_test_link(db, test_id=test_b.id, admin_id=user.id)
+    token_headers = authentication_token_from_email(
+        client=client, email=user.email, db=db
+    )
+
+    external_user_id = "375220"
+    first_response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={
+            "test_link_uuid": test_a_link.uuid,
+            "external_user_id": external_user_id,
+            "device_info": "Portal",
+        },
+        headers=token_headers,
+    )
+    assert first_response.status_code == 200
+    first_data = first_response.json()
+
+    second_response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={
+            "test_link_uuid": test_b_link.uuid,
+            "external_user_id": external_user_id,
+            "device_info": "Portal",
+        },
+        headers=token_headers,
+    )
+    assert second_response.status_code == 200
+    second_data = second_response.json()
+
+    # Same recurring user -> same candidate, but a distinct attempt per test.
+    assert second_data["candidate_uuid"] == first_data["candidate_uuid"]
+    assert second_data["candidate_test_id"] != first_data["candidate_test_id"]
+
+    second_candidate_test = db.get(CandidateTest, second_data["candidate_test_id"])
+    first_candidate_test = db.get(CandidateTest, first_data["candidate_test_id"])
+    assert second_candidate_test is not None
+    assert first_candidate_test is not None
+    assert second_candidate_test.candidate_id == first_candidate_test.candidate_id
+    assert second_candidate_test.test_id == test_b.id
+
+
+def test_external_provision_is_idempotent_for_same_user_and_test(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Re-provisioning the same (external user, test) returns the same attempt."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+    token_headers = authentication_token_from_email(
+        client=client, email=user.email, db=db
+    )
+
+    body = {
+        "test_link_uuid": test_link.uuid,
+        "external_user_id": "375220",
+        "device_info": "Portal",
+    }
+    first_data = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json=body,
+        headers=token_headers,
+    ).json()
+    second_data = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json=body,
+        headers=token_headers,
+    ).json()
+
+    assert second_data["candidate_uuid"] == first_data["candidate_uuid"]
+    assert second_data["candidate_test_id"] == first_data["candidate_test_id"]
+
+
+def test_external_provision_distinct_users_get_distinct_candidates(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Two different external users on the same test get different candidates."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+    token_headers = authentication_token_from_email(
+        client=client, email=user.email, db=db
+    )
+
+    first_data = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={"test_link_uuid": test_link.uuid, "external_user_id": "111"},
+        headers=token_headers,
+    ).json()
+    second_data = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={"test_link_uuid": test_link.uuid, "external_user_id": "222"},
+        headers=token_headers,
+    ).json()
+
+    assert first_data["candidate_uuid"] != second_data["candidate_uuid"]
+
+
+def test_external_start_rejects_candidate_test_for_other_test(
+    client: TestClient, db: SessionDep
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test_a = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    test_b = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test_a)
+    db.add(test_b)
+    db.commit()
+    db.refresh(test_a)
+    db.refresh(test_b)
+    test_a_link = get_test_link(db, test_id=test_a.id, admin_id=user.id)
+    test_b_link = get_test_link(db, test_id=test_b.id, admin_id=user.id)
+    token_headers = authentication_token_from_email(
+        client=client, email=user.email, db=db
+    )
+
+    provision_response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/provision",
+        json={
+            "test_link_uuid": test_a_link.uuid,
+            "external_user_id": "375220",
+            "device_info": "Portal",
+        },
+        headers=token_headers,
+    )
+    assert provision_response.status_code == 200
+    provision_data = provision_response.json()
+
+    start_response = client.post(
+        f"{settings.API_V1_STR}/candidate/external/start_test",
+        json={
+            "test_link_uuid": test_b_link.uuid,
+            "candidate_uuid": provision_data["candidate_uuid"],
+            "candidate_test_id": provision_data["candidate_test_id"],
+            "device_info": "Mobile",
+        },
+    )
+
+    assert start_response.status_code == 404
+    assert start_response.json()["detail"] == (
+        "Candidate test not found for this test link"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -24,6 +24,7 @@ from app.models.form import Form, FormField, FormFieldType, FormResponse
 from app.models.location import Country, District, State
 from app.models.organization_settings import (
     OrganizationSettings,
+    OrganizationSettingsPayload,
     default_organization_settings,
 )
 from app.models.question import QuestionTag, QuestionType
@@ -97,7 +98,7 @@ def create_single_choice_question_revision(
     return revision
 
 
-def enable_avanti_external_login(
+def enable_external_org_login(
     db: SessionDep, *, organization_id: int
 ) -> OrganizationSettings:
     payload = default_organization_settings()
@@ -15741,7 +15742,7 @@ def test_start_test_rejects_anonymous_for_external_login_org(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -15804,7 +15805,7 @@ def test_external_provision_requires_sashakt_auth(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -15894,7 +15895,7 @@ def test_external_provision_and_start_resume_same_attempt(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -15929,11 +15930,10 @@ def test_external_provision_and_start_resume_same_attempt(
     assert candidate_test.test_id == test.id
 
     start_response = client.post(
-        f"{settings.API_V1_STR}/candidate/external/start_test",
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": provision_data["candidate_uuid"]},
         json={
             "test_link_uuid": test_link.uuid,
-            "candidate_uuid": provision_data["candidate_uuid"],
-            "candidate_test_id": provision_data["candidate_test_id"],
             "device_info": "Mobile",
         },
     )
@@ -15950,7 +15950,7 @@ def test_external_start_reports_submitted_attempt(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -15988,11 +15988,10 @@ def test_external_start_reports_submitted_attempt(
     db.commit()
 
     start_response = client.post(
-        f"{settings.API_V1_STR}/candidate/external/start_test",
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": provision_data["candidate_uuid"]},
         json={
             "test_link_uuid": test_link.uuid,
-            "candidate_uuid": provision_data["candidate_uuid"],
-            "candidate_test_id": provision_data["candidate_test_id"],
             "device_info": "Mobile",
         },
     )
@@ -16010,7 +16009,7 @@ def test_external_provision_reuses_same_candidate_across_tests(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16083,7 +16082,7 @@ def test_external_provision_is_idempotent_for_same_user_and_test(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16130,7 +16129,7 @@ def test_external_provision_distinct_users_get_distinct_candidates(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16170,7 +16169,7 @@ def test_external_start_rejects_candidate_test_for_other_test(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16210,19 +16209,193 @@ def test_external_start_rejects_candidate_test_for_other_test(
     provision_data = provision_response.json()
 
     start_response = client.post(
-        f"{settings.API_V1_STR}/candidate/external/start_test",
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": provision_data["candidate_uuid"]},
         json={
             "test_link_uuid": test_b_link.uuid,
-            "candidate_uuid": provision_data["candidate_uuid"],
-            "candidate_test_id": provision_data["candidate_test_id"],
             "device_info": "Mobile",
         },
     )
 
     assert start_response.status_code == 404
     assert start_response.json()["detail"] == (
-        "Candidate test not found for this test link"
+        "Candidate test not found or invalid UUID"
     )
+
+
+def test_start_test_resume_requires_external_login_enabled(
+    client: TestClient, db: SessionDep
+) -> None:
+    """candidate_uuid resume is rejected when the org has external login disabled."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    candidate = Candidate(identity=uuid.uuid4(), organization_id=org.id)
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+    create_test_candidate_test(
+        db, admin_id=user.id, test_id=test.id, candidate_id=candidate.id
+    )
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": str(candidate.identity)},
+        json={"test_link_uuid": test_link.uuid, "device_info": "Mobile"},
+    )
+
+    assert response.status_code == 403
+    assert (
+        response.json()["detail"]
+        == "External login is not enabled for this organization"
+    )
+
+
+def test_start_test_resume_unknown_candidate_uuid(
+    client: TestClient, db: SessionDep
+) -> None:
+    """A candidate_uuid that was never provisioned resumes to a 404."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_external_org_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": str(uuid.uuid4())},
+        json={"test_link_uuid": test_link.uuid, "device_info": "Mobile"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Candidate test not found or invalid UUID"
+
+
+def test_start_test_anonymous_allowed_when_anonymous_starts_not_blocked(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Anonymous starts (no candidate_uuid) still work when external login is
+    enabled but block_anonymous_starts is off."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_external_org_login(db, organization_id=org.id)
+
+    settings_row = db.exec(
+        select(OrganizationSettings).where(
+            OrganizationSettings.organization_id == org.id
+        )
+    ).first()
+    assert settings_row is not None
+    payload = OrganizationSettingsPayload.model_validate(settings_row.settings)
+    payload.external_login.value.block_anonymous_starts = False
+    settings_row.settings = payload.model_dump(mode="json")
+    db.add(settings_row)
+    db.commit()
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        json={"test_link_uuid": test_link.uuid, "device_info": "Browser"},
+    )
+
+    assert response.status_code == 200
+    candidate_test = db.get(CandidateTest, response.json()["candidate_test_id"])
+    assert candidate_test is not None
+    candidate = db.get(Candidate, candidate_test.candidate_id)
+    assert candidate is not None
+    assert candidate.external_user_id is None
+
+
+def test_start_test_resume_respects_start_window(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Resuming via candidate_uuid still enforces the test's start_time window."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_external_org_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+        start_time=datetime(2025, 7, 6, 12, 30, 0),
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    candidate = Candidate(
+        identity=uuid.uuid4(), organization_id=org.id, external_user_id="375220"
+    )
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+    create_test_candidate_test(
+        db, admin_id=user.id, test_id=test.id, candidate_id=candidate.id
+    )
+
+    fake_now = datetime(2025, 7, 5, 12, 0, 0)
+    with patch("app.api.routes.candidate.get_current_time", return_value=fake_now):
+        response = client.post(
+            f"{settings.API_V1_STR}/candidate/start_test",
+            params={"candidate_uuid": str(candidate.identity)},
+            json={"test_link_uuid": test_link.uuid, "device_info": "Mobile"},
+        )
+
+    assert response.status_code == 400
+    assert "Test has not started yet" in response.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/api/routes/test_organization_settings.py
+++ b/backend/app/tests/api/routes/test_organization_settings.py
@@ -271,6 +271,40 @@ def test_put_settings_persists_round_trip(
     assert settings_body["answer_review"]["value"]["default"] == "end_of_test"
 
 
+def test_put_settings_preserves_external_login(
+    client: TestClient,
+    db: SessionDep,
+    get_user_systemadmin_token: dict[str, str],
+) -> None:
+    own_org_id = _get_org_id(client, get_user_systemadmin_token)
+    current = default_organization_settings()
+    current.external_login.value.enabled = True
+    current.external_login.value.block_anonymous_starts = True
+    db.add(
+        OrganizationSettings(
+            organization_id=own_org_id,
+            settings=current.model_dump(mode="json"),
+        )
+    )
+    db.commit()
+
+    new_payload = default_organization_settings()
+    new_payload.questions_per_page.value.question_pagination = 3
+
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+        json={"settings": new_payload.model_dump(mode="json")},
+    )
+    assert response.status_code == 200
+    body = response.json()["settings"]
+    assert body["questions_per_page"]["value"]["question_pagination"] == 3
+    assert body["external_login"]["value"] == {
+        "enabled": True,
+        "block_anonymous_starts": True,
+    }
+
+
 def test_put_settings_system_admin_other_org_forbidden(
     client: TestClient,
     get_user_systemadmin_token: dict[str, str],


### PR DESCRIPTION
## Summary

Adds Avanti external login. A partner portal (Avanti) launches a student into a Sashakt test on behalf of a logged-in org user, and **Sashakt owns the identity mapping**.

**Candidate reuse (the key design):** Sashakt stores an `external_user_id` on the candidate and looks **up-or-creates a single candidate per `(organization_id, external_user_id)`**. A recurring student therefore keeps **one stable candidate across all their tests**, instead of a fresh anonymous candidate per launch. Re-provisioning the same `(user, test)` is idempotent and returns the existing attempt. The anonymous QR-code flow is unchanged: `external_user_id` stays `NULL`, guarded by a partial unique index `(organization_id, external_user_id) WHERE external_user_id IS NOT NULL`.

Concretely:
- **Org settings** `external_login { enabled, block_anonymous_starts }` — org-level, controlled from DB/env, not Portal UI, disabled by default. `block_anonymous_starts` rejects the public QR/`start_test` path for portal-only orgs so a student can't bypass identity by scanning the link.
- **`POST /candidate/external/provision`** — authenticated as the logged-in Sashakt user, scoped to their org (404 on org mismatch). Look-up-or-creates the candidate by `(org, external_user_id)`, then find-or-creates the attempt. No shared provisioning secret.
- **`POST /candidate/external/start_test`** — resumes by `candidate_uuid` + `candidate_test_id`, reports `is_submitted` so a re-launched submitted attempt routes to results.
- **Result response** includes `external_user_id` for attribution on the result page.
- **Settings schema bumped to v6** (adds `external_login`); migrations stack linearly on `main` (`6f5c1d64e010 → add external_login (v6) → add candidate.external_user_id`). No merge-point migrations.

Note: `provider` was intentionally dropped — the organization already identifies the partner, so a separate provider field was redundant.

## How to review
- Settings model + migration: confirm org-level, disabled by default, v6.
- `candidate.py`: `_get_or_create_external_candidate` (reuse by org+external_user_id) and `_get_or_create_candidate_test` (idempotent attempt); `provision_external_candidate_test` requires `CurrentUser` + org scoping; `start_external_candidate_test` validates IDs against the test link.
- Tests: candidate reuse across tests, idempotent re-provision, distinct users → distinct candidates, anonymous path leaves `external_user_id` NULL, auth/enabled gating, resume, submitted-state reporting.

## Tested
- `pytest app/tests/api/routes/test_candidate.py -k 'external or anonymous_start_test_leaves or result'`
- `pytest app/tests/api/routes/test_organization_settings.py -k 'version or put_settings or external'`
- `mypy app`, `ruff check app` clean; single alembic head, reversible migrations
- Verified end-to-end against a running stack (portal → provision → webapp → submit): same user reuses one candidate across multiple tests; new attempt per test; correct scoring.

## Related
- sashakt-webapp#231 (external launch flow), sashakt-portal#464 (schema v6)
- Follow-ups: sashakt-webapp#264 (section summary), sashakt-webapp#265 (display_id on result page)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-level external login configuration (including anonymous-start blocking).
  * Introduced external candidate test APIs to provision and start tests using a test link: `/candidate/external/provision` and `/candidate/external/start_test`.
  * Anonymous starting is now blocked when external login settings require it.
* **Bug Fixes**
  * Prevented answering submissions after a candidate test has already been submitted.
  * External login settings are preserved when updating other organization settings.
* **Tests**
  * Added end-to-end coverage for provisioning, starting, authorization/provider validation, and resuming submitted tests.
* **Chores**
  * Added database migration(s) and updated the organization settings schema version to support external login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

