### PR TITLE
Allow nullable answer time spent

### DIFF
--- a/backend/app/alembic/versions/c2f7d9a4b8e1_make_answer_time_spent_nullable.py
+++ b/backend/app/alembic/versions/c2f7d9a4b8e1_make_answer_time_spent_nullable.py
@@ -31,3 +31,10 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute("UPDATE candidate_test_answer SET time_spent = 0 WHERE time_spent IS NULL")
+    op.alter_column(
+        "candidate_test_answer",
+        "time_spent",
+        existing_type=sa.Integer(),
+        nullable=False,
+        server_default=None,
+    )

--- a/backend/app/alembic/versions/c2f7d9a4b8e1_make_answer_time_spent_nullable.py
+++ b/backend/app/alembic/versions/c2f7d9a4b8e1_make_answer_time_spent_nullable.py
@@ -1,0 +1,33 @@
+"""make answer time spent nullable
+
+Revision ID: c2f7d9a4b8e1
+Revises: b3e9f2a1c047
+Create Date: 2026-05-29 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c2f7d9a4b8e1"
+down_revision: str | Sequence[str] | None = "b3e9f2a1c047"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "candidate_test_answer",
+        "time_spent",
+        existing_type=sa.Integer(),
+        nullable=True,
+        server_default=None,
+    )
+    op.execute("UPDATE candidate_test_answer SET time_spent = NULL WHERE time_spent = 0")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE candidate_test_answer SET time_spent = 0 WHERE time_spent IS NULL")

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -29,7 +29,7 @@ class CandidateTestAnswerBase(SQLModel):
     )
     response: str | None = Field(nullable=True, default=None)
     visited: bool = Field(nullable=False, default=False)
-    time_spent: int = Field(nullable=True, default=0)
+    time_spent: int | None = Field(default=None, nullable=True)
     bookmarked: bool = Field(
         default=False,
         sa_column_kwargs={"server_default": "false"},
@@ -85,7 +85,7 @@ class CandidateReviewResponse(SQLModel):
 class CandidateTestAnswerUpdate(SQLModel):
     response: str | None
     visited: bool
-    time_spent: int
+    time_spent: int | None = None
     bookmarked: bool | None = None
 
 
@@ -96,7 +96,7 @@ class CandidateAnswerSubmitRequest(SQLModel):
     question_revision_id: int
     response: str | None = None
     visited: bool = False
-    time_spent: int = 0
+    time_spent: int | None = None
     bookmarked: bool = False
 
 

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -11503,7 +11503,6 @@ def test_submit_answer_bookmark_default_false(
         "question_revision_id": question_revision.id,
         "response": "[2]",
         "visited": True,
-        "time_spent": 15,
     }
 
     response = client.post(
@@ -11515,6 +11514,7 @@ def test_submit_answer_bookmark_default_false(
     assert response.status_code == 200
     data = response.json()
     assert data["bookmarked"] is False
+    assert data["time_spent"] is None
 
 
 def test_update_answer_bookmark_status(client: TestClient, db: SessionDep) -> None:


### PR DESCRIPTION
## Summary
- allow candidate answer time_spent to be omitted/null instead of defaulting to 0
- add an Alembic migration that converts existing zero values to NULL
- update submit-answer coverage for missing time_spent

Closes #501

## Verification
- uv run ruff check app/models/candidate.py app/tests/api/routes/test_candidate.py app/alembic/versions/c2f7d9a4b8e1_make_answer_time_spent_nullable.py
- UPLOAD_ROOT=/tmp/app/uploads uv run pytest app/tests/api/routes/test_candidate.py -k bookmark_default_false

Note: the upload-root env var was only used locally to avoid the existing /app/uploads local test issue; it is not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated time spent tracking on answers to support optional values. The system now properly handles cases where time spent is not recorded, instead of defaulting to zero.

* **Chores**
  * Database schema updated to support nullable time spent values. Existing zero values have been normalized to reflect unrecorded time data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->