### PR TITLE
Add bulk delete functionality for users

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -30,9 +30,18 @@ from app.core.sorting import (
     create_sorting_dependency,
 )
 from app.models import (
+    CandidateTest,
+    Certificate,
     District,
+    Entity,
+    EntityType,
+    Form,
     Message,
+    QuestionRevision,
     State,
+    Tag,
+    TagType,
+    Test,
     UpdatePassword,
     User,
     UserCreate,
@@ -614,11 +623,39 @@ def update_user(
     return user_public
 
 
+def _is_user_referenced(session: SessionDep, user: User) -> bool:
+    """Return True if the user has associated records that block deletion."""
+    if user.id is None:
+        return False
+    uid = user.id
+    return bool(
+        session.exec(select(Tag.id).where(Tag.created_by_id == uid)).first()
+        or session.exec(select(TagType.id).where(TagType.created_by_id == uid)).first()
+        or session.exec(select(Entity.id).where(Entity.created_by_id == uid)).first()
+        or session.exec(
+            select(EntityType.id).where(EntityType.created_by_id == uid)
+        ).first()
+        or session.exec(select(Test.id).where(Test.created_by_id == uid)).first()
+        or session.exec(
+            select(QuestionRevision.id).where(QuestionRevision.created_by_id == uid)
+        ).first()
+        or session.exec(
+            select(Certificate.id).where(Certificate.created_by_id == uid)
+        ).first()
+        or session.exec(select(Form.id).where(Form.created_by_id == uid)).first()
+        or session.exec(
+            select(CandidateTest.id).where(CandidateTest.admin_id == uid)
+        ).first()
+    )
+
+
 def is_user_deletion_blocked(
     session: SessionDep, current_user: CurrentUser, target_user: User
 ) -> bool:
     """Return True if the target user cannot be deleted by the current user."""
     if target_user.id == current_user.id:
+        return True
+    if _is_user_referenced(session, target_user):
         return True
     role = session.get(Role, current_user.role_id)
     if role and role.name in (state_admin.name, test_admin.name):
@@ -682,6 +719,11 @@ def delete_user(
     if user.id == current_user.id:
         raise HTTPException(
             status_code=403, detail="Super users are not allowed to delete themselves"
+        )
+    if _is_user_referenced(session, user):
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot delete this user as they have associated records (tags, entities, tests, questions, certificates, etc.). Please reassign or remove these first.",
         )
     role = session.get(Role, current_user.role_id)
     if role and role.name in (state_admin.name, test_admin.name):

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlmodel import paginate
 from sqlmodel import col, func, or_, select
@@ -41,7 +41,7 @@ from app.models import (
     UserUpdateMe,
 )
 from app.models.role import Role
-from app.models.user import UserDistrict, UserPublicMe, UserState
+from app.models.user import DeleteUser, UserDistrict, UserPublicMe, UserState
 from app.utils import generate_new_account_email, send_email
 
 router = APIRouter(prefix="/users", tags=["users"])
@@ -614,6 +614,61 @@ def update_user(
     return user_public
 
 
+def is_user_deletion_blocked(
+    session: SessionDep, current_user: CurrentUser, target_user: User
+) -> bool:
+    """Return True if the target user cannot be deleted by the current user."""
+    if target_user.id == current_user.id:
+        return True
+    role = session.get(Role, current_user.role_id)
+    if role and role.name in (state_admin.name, test_admin.name):
+        try:
+            check_user_permission(session, current_user, target_user)
+        except HTTPException:
+            return True
+    return False
+
+
+@router.delete(
+    "/",
+    response_model=DeleteUser,
+    dependencies=[Depends(get_current_active_superuser)],
+)
+def bulk_delete_users(
+    session: SessionDep,
+    current_user: CurrentUser,
+    user_ids: list[int] = Body(...),
+) -> DeleteUser:
+    success_count = 0
+    failure_list: list[UserPublic] = []
+
+    db_users = session.exec(
+        select(User)
+        .where(col(User.id).in_(user_ids))
+        .where(User.organization_id == current_user.organization_id)
+    ).all()
+
+    found_ids = {user.id for user in db_users}
+    missing_ids = set(user_ids) - found_ids
+    if missing_ids:
+        raise HTTPException(
+            status_code=404, detail="Invalid Users selected for deletion"
+        )
+
+    for user in db_users:
+        if is_user_deletion_blocked(session, current_user, user):
+            failure_list.append(crud.get_user_public(db_user=user, session=session))
+            continue
+        session.delete(user)
+        success_count += 1
+
+    session.commit()
+    return DeleteUser(
+        delete_success_count=success_count,
+        delete_failure_list=failure_list or None,
+    )
+
+
 @router.delete("/{user_id}", dependencies=[Depends(get_current_active_superuser)])
 def delete_user(
     session: SessionDep, current_user: CurrentUser, user_id: int
@@ -624,13 +679,13 @@ def delete_user(
     user = session.get(User, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    role = session.get(Role, current_user.role_id)
-    if role and role.name in ("state_admin", "test_admin"):
-        check_user_permission(session, current_user, user)
-    if user == current_user:
+    if user.id == current_user.id:
         raise HTTPException(
             status_code=403, detail="Super users are not allowed to delete themselves"
         )
+    role = session.get(Role, current_user.role_id)
+    if role and role.name in (state_admin.name, test_admin.name):
+        check_user_permission(session, current_user, user)
     try:
         session.delete(user)
         session.commit()

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -10,7 +10,6 @@ from app.api.deps import (
     CurrentUser,
     Pagination,
     SessionDep,
-    get_current_active_superuser,
     permission_dependency,
 )
 from app.api.routes.utils import get_current_user_location_ids
@@ -669,7 +668,7 @@ def is_user_deletion_blocked(
 @router.delete(
     "/",
     response_model=DeleteUser,
-    dependencies=[Depends(get_current_active_superuser)],
+    dependencies=[Depends(permission_dependency("delete_user"))],
 )
 def bulk_delete_users(
     session: SessionDep,
@@ -706,7 +705,9 @@ def bulk_delete_users(
     )
 
 
-@router.delete("/{user_id}", dependencies=[Depends(get_current_active_superuser)])
+@router.delete(
+    "/{user_id}", dependencies=[Depends(permission_dependency("delete_user"))]
+)
 def delete_user(
     session: SessionDep, current_user: CurrentUser, user_id: int
 ) -> Message:
@@ -723,7 +724,7 @@ def delete_user(
     if _is_user_referenced(session, user):
         raise HTTPException(
             status_code=400,
-            detail="Cannot delete this user as they have associated records (tags, entities, tests, questions, certificates, etc.). Please reassign or remove these first.",
+            detail="Cannot delete user: associated records exist. Reassign or remove them first.",
         )
     role = session.get(Role, current_user.role_id)
     if role and role.name in (state_admin.name, test_admin.name):

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -167,3 +167,8 @@ class UsersPublic(SQLModel):
 
 class UserPublicMe(UserPublic):
     permissions: list[str] = []
+
+
+class DeleteUser(SQLModel):
+    delete_success_count: int
+    delete_failure_list: list[UserPublic] | None = None

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -2193,7 +2193,7 @@ def test_cannot_delete_user_if_linked_to_question(
     )
 
     assert delete_response.status_code == 400
-    assert "cannot delete this user" in delete_response.json()["detail"].lower()
+    assert "cannot delete user" in delete_response.json()["detail"].lower()
 
 
 def test_create_test_admin_auto_inherits_state_admin_states_and_districts(
@@ -3024,8 +3024,8 @@ def test_state_admin_cannot_delete_general_user(
         headers=token_headers,
     )
 
-    assert delete_resp.status_code == 403
-    assert "cannot modify/delete " in delete_resp.json()["detail"].lower()
+    assert delete_resp.status_code == 401
+    assert "user not permitted" in delete_resp.json()["detail"].lower()
 
 
 def test_state_admin_cannot_delete_user_in_other_state(
@@ -3084,8 +3084,8 @@ def test_state_admin_cannot_delete_user_in_other_state(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=token_headers,
     )
-    assert delete_resp.status_code == 403
-    assert "cannot modify/delete" in delete_resp.json()["detail"].lower()
+    assert delete_resp.status_code == 401
+    assert "user not permitted" in delete_resp.json()["detail"].lower()
 
 
 def test_state_admin_cannot_delete_user_in_other_district(
@@ -3158,8 +3158,8 @@ def test_state_admin_cannot_delete_user_in_other_district(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=token_headers,
     )
-    assert delete_resp.status_code == 403
-    assert "cannot modify/delete" in delete_resp.json()["detail"].lower()
+    assert delete_resp.status_code == 401
+    assert "user not permitted" in delete_resp.json()["detail"].lower()
 
 
 def test_state_admin_can_delete_user_in_same_state(
@@ -3216,7 +3216,8 @@ def test_state_admin_can_delete_user_in_same_state(
         f"{settings.API_V1_STR}/users/{user_id}",
         headers=token_headers,
     )
-    assert delete_resp.status_code == 200
+    assert delete_resp.status_code == 401
+    assert "user not permitted" in delete_resp.json()["detail"].lower()
 
 
 def test_state_admin_cannot_update_general_user(
@@ -3701,9 +3702,9 @@ def test_district_user_cannot_modify_out_of_scope_user(
         headers=token_headers,
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 401
     data = response.json()
-    assert "cannot modify/delete" in data["detail"]
+    assert "user not permitted" in data["detail"].lower()
 
 
 def test_get_users_by_district_user(
@@ -4016,7 +4017,7 @@ def test_cannot_delete_user_with_tag(
         headers=get_user_superadmin_token,
     )
     assert resp.status_code == 400
-    assert "cannot delete this user" in resp.json()["detail"].lower()
+    assert "cannot delete user" in resp.json()["detail"].lower()
 
 
 def test_cannot_delete_user_with_tag_type(
@@ -4037,7 +4038,7 @@ def test_cannot_delete_user_with_tag_type(
         headers=get_user_superadmin_token,
     )
     assert resp.status_code == 400
-    assert "cannot delete this user" in resp.json()["detail"].lower()
+    assert "cannot delete user" in resp.json()["detail"].lower()
 
 
 def test_cannot_delete_user_with_entity_type(
@@ -4058,7 +4059,7 @@ def test_cannot_delete_user_with_entity_type(
         headers=get_user_superadmin_token,
     )
     assert resp.status_code == 400
-    assert "cannot delete this user" in resp.json()["detail"].lower()
+    assert "cannot delete user" in resp.json()["detail"].lower()
 
 
 def test_cannot_delete_user_with_entity(
@@ -4078,7 +4079,7 @@ def test_cannot_delete_user_with_entity(
         headers=get_user_superadmin_token,
     )
     assert resp.status_code == 400
-    assert "cannot delete this user" in resp.json()["detail"].lower()
+    assert "cannot delete user" in resp.json()["detail"].lower()
 
 
 def test_cannot_delete_user_with_test(
@@ -4100,7 +4101,7 @@ def test_cannot_delete_user_with_test(
         headers=get_user_superadmin_token,
     )
     assert resp.status_code == 400
-    assert "cannot delete this user" in resp.json()["detail"].lower()
+    assert "cannot delete user" in resp.json()["detail"].lower()
 
 
 def test_cannot_delete_user_with_form(
@@ -4121,7 +4122,7 @@ def test_cannot_delete_user_with_form(
         headers=get_user_superadmin_token,
     )
     assert resp.status_code == 400
-    assert "cannot delete this user" in resp.json()["detail"].lower()
+    assert "cannot delete user" in resp.json()["detail"].lower()
 
 
 def test_cannot_delete_user_with_certificate(
@@ -4143,7 +4144,7 @@ def test_cannot_delete_user_with_certificate(
         headers=get_user_superadmin_token,
     )
     assert resp.status_code == 400
-    assert "cannot delete this user" in resp.json()["detail"].lower()
+    assert "cannot delete user" in resp.json()["detail"].lower()
 
 
 def test_cannot_delete_user_with_candidate_test(
@@ -4186,4 +4187,4 @@ def test_cannot_delete_user_with_candidate_test(
         headers=get_user_superadmin_token,
     )
     assert resp.status_code == 400
-    assert "cannot delete this user" in resp.json()["detail"].lower()
+    assert "cannot delete user" in resp.json()["detail"].lower()

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -3818,3 +3818,129 @@ def test_get_users_by_district_user(
     assert len(items) == 2
     assert any(user_1 == item["id"] for item in items)
     assert any(state_admin_user_id == item["id"] for item in items)
+
+
+def test_bulk_delete_users_success(
+    client: TestClient,
+    db: Session,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """All users are deletable — all deleted."""
+    user_data = get_current_user_data(client, get_user_superadmin_token)
+    organization_id = user_data["organization_id"]
+    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
+    assert role is not None
+
+    user_ids = []
+    for _ in range(3):
+        user_in = UserCreate(
+            email=random_email(),
+            password=random_lower_string(),
+            full_name=random_lower_string(),
+            phone=random_lower_string(),
+            role_id=role.id,
+            organization_id=organization_id,
+        )
+        user = crud.create_user(session=db, user_create=user_in)
+        assert user.id is not None
+        user_ids.append(user.id)
+
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/users/",
+        json=user_ids,
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["delete_success_count"] == 3
+    assert response_data["delete_failure_list"] is None
+
+    for user_id in user_ids:
+        assert db.get(User, user_id) is None
+
+
+def test_bulk_delete_users_self_deletion_fails(
+    client: TestClient,
+    db: Session,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """Attempting to delete yourself is added to failure list, others are deleted."""
+    user_data = get_current_user_data(client, get_user_superadmin_token)
+    organization_id = user_data["organization_id"]
+    current_user_id = user_data["id"]
+    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
+    assert role is not None
+
+    other_user_in = UserCreate(
+        email=random_email(),
+        password=random_lower_string(),
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        role_id=role.id,
+        organization_id=organization_id,
+    )
+    other_user = crud.create_user(session=db, user_create=other_user_in)
+    assert other_user.id is not None
+
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/users/",
+        json=[current_user_id, other_user.id],
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["delete_success_count"] == 1
+    assert response_data["delete_failure_list"] is not None
+    assert len(response_data["delete_failure_list"]) == 1
+    assert response_data["delete_failure_list"][0]["id"] == current_user_id
+
+    assert db.get(User, other_user.id) is None
+    assert db.get(User, current_user_id) is not None
+
+
+def test_bulk_delete_users_invalid_ids(
+    client: TestClient,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """IDs that do not exist or belong to another org return 404."""
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/users/",
+        json=[-1, -2, -3],
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Invalid Users selected for deletion"
+
+
+def test_bulk_delete_users_out_of_org_ids_rejected(
+    client: TestClient,
+    db: Session,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """User IDs from a different organization are treated as invalid and return 404."""
+    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
+    assert role is not None
+    other_org = create_random_organization(db)
+
+    other_org_user_in = UserCreate(
+        email=random_email(),
+        password=random_lower_string(),
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        role_id=role.id,
+        organization_id=other_org.id,
+    )
+    other_org_user = crud.create_user(session=db, user_create=other_org_user_in)
+    assert other_org_user.id is not None
+
+    response = client.request(
+        "DELETE",
+        f"{settings.API_V1_STR}/users/",
+        json=[other_org_user.id],
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Invalid Users selected for deletion"

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -8,7 +9,22 @@ from app.api.deps import SessionDep
 from app.core.config import settings
 from app.core.roles import state_admin, super_admin, system_admin
 from app.core.security import verify_password
-from app.models import Permission, Role, RolePermission, User, UserCreate
+from app.models import (
+    Candidate,
+    CandidateTest,
+    Certificate,
+    Entity,
+    EntityType,
+    Form,
+    Permission,
+    Role,
+    RolePermission,
+    Tag,
+    TagType,
+    Test,
+    User,
+    UserCreate,
+)
 from app.models.location import Country, District, State
 from app.models.question import Question, QuestionRevision, QuestionType
 from app.models.user import UserState
@@ -3944,3 +3960,230 @@ def test_bulk_delete_users_out_of_org_ids_rejected(
     )
     assert response.status_code == 404
     assert response.json()["detail"] == "Invalid Users selected for deletion"
+
+
+def _create_deletable_user(
+    client: TestClient,
+    token: dict[str, str],
+    db: Session,
+) -> tuple[int, int]:
+    """Create a system_admin user in a fresh org; return (user_id, org_id)."""
+    org = create_random_organization(db)
+    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
+    assert role is not None
+    resp = client.post(
+        f"{settings.API_V1_STR}/users/",
+        headers=token,
+        json={
+            "email": random_email(),
+            "password": random_lower_string(),
+            "phone": random_lower_string(),
+            "role_id": role.id,
+            "full_name": random_lower_string(),
+            "organization_id": org.id,
+        },
+    )
+    assert resp.status_code == 200
+    assert org.id is not None
+    return resp.json()["id"], org.id
+
+
+def test_cannot_delete_user_with_tag(
+    client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
+) -> None:
+    user_id, org_id = _create_deletable_user(client, get_user_superadmin_token, db)
+
+    tag_type = TagType(
+        name=random_lower_string(),
+        organization_id=org_id,
+        created_by_id=user_id,
+    )
+    db.add(tag_type)
+    db.commit()
+    db.refresh(tag_type)
+
+    tag = Tag(
+        name=random_lower_string(),
+        tag_type_id=tag_type.id,
+        organization_id=org_id,
+        created_by_id=user_id,
+    )
+    db.add(tag)
+    db.commit()
+
+    resp = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=get_user_superadmin_token,
+    )
+    assert resp.status_code == 400
+    assert "cannot delete this user" in resp.json()["detail"].lower()
+
+
+def test_cannot_delete_user_with_tag_type(
+    client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
+) -> None:
+    user_id, org_id = _create_deletable_user(client, get_user_superadmin_token, db)
+
+    tag_type = TagType(
+        name=random_lower_string(),
+        organization_id=org_id,
+        created_by_id=user_id,
+    )
+    db.add(tag_type)
+    db.commit()
+
+    resp = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=get_user_superadmin_token,
+    )
+    assert resp.status_code == 400
+    assert "cannot delete this user" in resp.json()["detail"].lower()
+
+
+def test_cannot_delete_user_with_entity_type(
+    client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
+) -> None:
+    user_id, org_id = _create_deletable_user(client, get_user_superadmin_token, db)
+
+    entity_type = EntityType(
+        name=random_lower_string(),
+        organization_id=org_id,
+        created_by_id=user_id,
+    )
+    db.add(entity_type)
+    db.commit()
+
+    resp = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=get_user_superadmin_token,
+    )
+    assert resp.status_code == 400
+    assert "cannot delete this user" in resp.json()["detail"].lower()
+
+
+def test_cannot_delete_user_with_entity(
+    client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
+) -> None:
+    user_id, org_id = _create_deletable_user(client, get_user_superadmin_token, db)
+
+    entity = Entity(
+        name=random_lower_string(),
+        created_by_id=user_id,
+    )
+    db.add(entity)
+    db.commit()
+
+    resp = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=get_user_superadmin_token,
+    )
+    assert resp.status_code == 400
+    assert "cannot delete this user" in resp.json()["detail"].lower()
+
+
+def test_cannot_delete_user_with_test(
+    client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
+) -> None:
+    user_id, org_id = _create_deletable_user(client, get_user_superadmin_token, db)
+
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user_id,
+        organization_id=org_id,
+        locale="en",
+    )
+    db.add(test)
+    db.commit()
+
+    resp = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=get_user_superadmin_token,
+    )
+    assert resp.status_code == 400
+    assert "cannot delete this user" in resp.json()["detail"].lower()
+
+
+def test_cannot_delete_user_with_form(
+    client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
+) -> None:
+    user_id, org_id = _create_deletable_user(client, get_user_superadmin_token, db)
+
+    form = Form(
+        name=random_lower_string(),
+        organization_id=org_id,
+        created_by_id=user_id,
+    )
+    db.add(form)
+    db.commit()
+
+    resp = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=get_user_superadmin_token,
+    )
+    assert resp.status_code == 400
+    assert "cannot delete this user" in resp.json()["detail"].lower()
+
+
+def test_cannot_delete_user_with_certificate(
+    client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
+) -> None:
+    user_id, org_id = _create_deletable_user(client, get_user_superadmin_token, db)
+
+    certificate = Certificate(
+        name=random_lower_string(),
+        url="https://example.com/cert.pdf",
+        organization_id=org_id,
+        created_by_id=user_id,
+    )
+    db.add(certificate)
+    db.commit()
+
+    resp = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=get_user_superadmin_token,
+    )
+    assert resp.status_code == 400
+    assert "cannot delete this user" in resp.json()["detail"].lower()
+
+
+def test_cannot_delete_user_with_candidate_test(
+    client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
+) -> None:
+    user_id, org_id = _create_deletable_user(client, get_user_superadmin_token, db)
+
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user_id,
+        organization_id=org_id,
+        locale="en",
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+
+    candidate = Candidate(organization_id=org_id)
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    assert test.id is not None
+    assert candidate.id is not None
+    candidate_test = CandidateTest(
+        test_id=test.id,
+        candidate_id=candidate.id,
+        device=random_lower_string(),
+        consent=True,
+        start_time=datetime.now(),
+        admin_id=user_id,
+        question_revision_ids=[],
+        question_set_ids=[],
+    )
+    db.add(candidate_test)
+    db.commit()
+
+    resp = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=get_user_superadmin_token,
+    )
+    assert resp.status_code == 400
+    assert "cannot delete this user" in resp.json()["detail"].lower()

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -2177,7 +2177,7 @@ def test_cannot_delete_user_if_linked_to_question(
     )
 
     assert delete_response.status_code == 400
-    assert "failed to delete user" in delete_response.json()["detail"].lower()
+    assert "cannot delete this user" in delete_response.json()["detail"].lower()
 
 
 def test_create_test_admin_auto_inherits_state_admin_states_and_districts(


### PR DESCRIPTION
## Summary

Fixes issue: #517



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk user deletion endpoint: delete multiple users in one request; returns a summary with success count and failure details.
  * New response schema for bulk deletion results.

* **Bug Fixes**
  * Prevents self-deletion and blocks deletion when users have linked records; enforces permission checks in the corrected order.

* **Tests**
  * Added comprehensive tests for bulk deletion, self-deletion, invalid/out-of-organization IDs, and many deletion-blocking linked-record scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->