### PR TITLE
Refactor organization creation and update endpoints to use form data;…

### DIFF
--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -196,7 +196,7 @@ async def create_organization(
     logo: UploadFile | None = File(
         None, description="Organization logo (PNG, JPG, WebP, max 2MB)"
     ),
-) -> Organization:
+) -> OrganizationPublic:
     organization = Organization(
         name=name,
         description=description,
@@ -230,7 +230,7 @@ async def create_organization(
             delete_logo_file(new_logo_path)
         raise
 
-    return organization
+    return transform_organizations_to_public([organization])[0]
 
 
 # Get all Organizations
@@ -392,11 +392,13 @@ def get_organization_aggregated_stats_for_current_user(
     response_model=OrganizationPublic,
     dependencies=[Depends(permission_dependency("read_organization"))],
 )
-def get_organization_by_id(organization_id: int, session: SessionDep) -> Organization:
+def get_organization_by_id(
+    organization_id: int, session: SessionDep
+) -> OrganizationPublic:
     organization = session.get(Organization, organization_id)
     if not organization or organization.is_deleted is True:
         raise HTTPException(status_code=404, detail="Organization not found")
-    return organization
+    return transform_organizations_to_public([organization])[0]
 
 
 # Update a Organization
@@ -416,7 +418,7 @@ async def update_organization(
     logo: UploadFile | None = File(
         None, description="Organization logo (PNG, JPG, WebP, max 2MB)"
     ),
-) -> Organization:
+) -> OrganizationPublic:
     organization = session.get(Organization, organization_id)
     if not organization or organization.is_deleted is True:
         raise HTTPException(status_code=404, detail="Organization not found")
@@ -456,7 +458,7 @@ async def update_organization(
     if new_logo_path and old_logo_path and old_logo_path != new_logo_path:
         delete_logo_file(old_logo_path)
 
-    return organization
+    return transform_organizations_to_public([organization])[0]
 
 
 # Set Visibility of Organization
@@ -469,7 +471,7 @@ def visibility_organization(
     organization_id: int,
     session: SessionDep,
     is_active: bool = Query(False, description="Set visibility of organization"),
-) -> Organization:
+) -> OrganizationPublic:
     organization = session.get(Organization, organization_id)
     if not organization or organization.is_deleted is True:
         raise HTTPException(status_code=404, detail="Organization not found")
@@ -477,7 +479,7 @@ def visibility_organization(
     session.add(organization)
     session.commit()
     session.refresh(organization)
-    return organization
+    return transform_organizations_to_public([organization])[0]
 
 
 # Delete a Organization

--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -26,10 +26,8 @@ from app.models import (
     AggregatedData,
     Message,
     Organization,
-    OrganizationCreate,
     OrganizationPublic,
     OrganizationSettings,
-    OrganizationUpdate,
     Question,
     Test,
     User,
@@ -188,21 +186,50 @@ async def delete_current_organization_logo(
     response_model=OrganizationPublic,
     dependencies=[Depends(permission_dependency("create_organization"))],
 )
-def create_organization(
-    organization_create: OrganizationCreate, session: SessionDep
+async def create_organization(
+    *,
+    session: SessionDep,
+    name: str = Form(...),
+    description: str | None = Form(None),
+    is_active: bool = Form(True),
+    shortcode: str | None = Form(None),
+    logo: UploadFile | None = File(
+        None, description="Organization logo (PNG, JPG, WebP, max 2MB)"
+    ),
 ) -> Organization:
-    organization = Organization.model_validate(organization_create)
+    organization = Organization(
+        name=name,
+        description=description,
+        is_active=is_active,
+        shortcode=shortcode,
+    )
     session.add(organization)
     session.flush()
     assert organization.id is not None
+
+    new_logo_path = None
+    if logo is not None:
+        file_content, file_ext = await validate_logo_upload(logo)
+        new_logo_path = save_logo_file(organization.id, file_content, file_ext)
+        organization.logo = new_logo_path
+        session.add(organization)
+
     session.add(
         OrganizationSettings(
             organization_id=organization.id,
             settings=copy.deepcopy(DEFAULT_ORGANIZATION_SETTINGS),
         )
     )
-    session.commit()
-    session.refresh(organization)
+
+    try:
+        session.commit()
+        session.refresh(organization)
+    except Exception:
+        session.rollback()
+        if new_logo_path:
+            delete_logo_file(new_logo_path)
+        raise
+
     return organization
 
 
@@ -378,19 +405,57 @@ def get_organization_by_id(organization_id: int, session: SessionDep) -> Organiz
     response_model=OrganizationPublic,
     dependencies=[Depends(permission_dependency("update_organization"))],
 )
-def update_organization(
+async def update_organization(
+    *,
     organization_id: int,
-    updated_data: OrganizationUpdate,
     session: SessionDep,
+    name: str | None = Form(None),
+    description: str | None = Form(None),
+    is_active: bool | None = Form(None),
+    shortcode: str | None = Form(None),
+    logo: UploadFile | None = File(
+        None, description="Organization logo (PNG, JPG, WebP, max 2MB)"
+    ),
 ) -> Organization:
     organization = session.get(Organization, organization_id)
     if not organization or organization.is_deleted is True:
         raise HTTPException(status_code=404, detail="Organization not found")
-    organization_data = updated_data.model_dump(exclude_unset=True)
-    organization.sqlmodel_update(organization_data)
-    session.add(organization)
-    session.commit()
-    session.refresh(organization)
+
+    old_logo_path = organization.logo
+    new_logo_path = None
+
+    if logo is not None:
+        file_content, file_ext = await validate_logo_upload(logo)
+        new_logo_path = save_logo_file(organization_id, file_content, file_ext)
+
+    update_data: dict[str, object] = {}
+    if name is not None:
+        update_data["name"] = name
+    if description is not None:
+        update_data["description"] = description
+    if is_active is not None:
+        update_data["is_active"] = is_active
+    if shortcode is not None:
+        update_data["shortcode"] = shortcode
+    if new_logo_path is not None:
+        update_data["logo"] = new_logo_path
+
+    if update_data:
+        organization.sqlmodel_update(update_data)
+        session.add(organization)
+
+    try:
+        session.commit()
+        session.refresh(organization)
+    except Exception:
+        session.rollback()
+        if new_logo_path:
+            delete_logo_file(new_logo_path)
+        raise
+
+    if new_logo_path and old_logo_path and old_logo_path != new_logo_path:
+        delete_logo_file(old_logo_path)
+
     return organization
 
 

--- a/backend/app/core/files.py
+++ b/backend/app/core/files.py
@@ -302,8 +302,9 @@ def get_absolute_logo_url(relative_path: str | None) -> str | None:
     if not relative_path:
         return None
 
-    scheme = "https" if settings.ENVIRONMENT != "local" else "http"
-    return f"{scheme}://{settings.DOMAIN}{relative_path}"
+    if settings.ENVIRONMENT == "local":
+        return f"http://{settings.DOMAIN}:8000{relative_path}"
+    return f"https://{settings.DOMAIN}{relative_path}"
 
 
 # Platform guide PDF functions
@@ -418,5 +419,6 @@ def get_absolute_platform_guide_url(relative_path: str | None) -> str | None:
     if not relative_path:
         return None
 
-    scheme = "https" if settings.ENVIRONMENT != "local" else "http"
-    return f"{scheme}://{settings.DOMAIN}{relative_path}"
+    if settings.ENVIRONMENT == "local":
+        return f"http://{settings.DOMAIN}:8000{relative_path}"
+    return f"https://{settings.DOMAIN}{relative_path}"

--- a/backend/app/tests/api/routes/test_organization.py
+++ b/backend/app/tests/api/routes/test_organization.py
@@ -44,7 +44,7 @@ def test_create_organization(
     description = random_lower_string()
     response = client.post(
         f"{settings.API_V1_STR}/organization/",
-        json={
+        data={
             "name": name,
             "description": description,
         },
@@ -59,7 +59,7 @@ def test_create_organization(
     assert data["is_active"] is True
     response = client.post(
         f"{settings.API_V1_STR}/organization/",
-        json={
+        data={
             "name": name,
             "description": description,
         },
@@ -386,7 +386,7 @@ def test_update_organization(
     db.commit()
     response = client.put(
         f"{settings.API_V1_STR}/organization/{jal_vikas.id}",
-        json={"name": updated_name, "description": None},
+        data={"name": updated_name},
         headers=get_user_superadmin_token,
     )
     data = response.json()
@@ -398,7 +398,7 @@ def test_update_organization(
 
     response = client.put(
         f"{settings.API_V1_STR}/organization/{jal_vikas.id}",
-        json={"name": jal_vikas.name, "description": inital_description},
+        data={"name": jal_vikas.name, "description": inital_description},
         headers=get_user_superadmin_token,
     )
     data = response.json()
@@ -409,7 +409,7 @@ def test_update_organization(
 
     response = client.put(
         f"{settings.API_V1_STR}/organization/{jal_vikas.id}",
-        json={"name": jal_vikas.name, "description": updated_description},
+        data={"name": jal_vikas.name, "description": updated_description},
         headers=get_user_superadmin_token,
     )
     data = response.json()

--- a/backend/app/tests/api/routes/test_organization.py
+++ b/backend/app/tests/api/routes/test_organization.py
@@ -480,6 +480,7 @@ def test_update_organization_by_id_with_logo(
     db.add(org)
     db.commit()
     db.refresh(org)
+    assert org.id is not None
 
     logo_file = create_test_image(width=200, height=200, format="PNG")
     response = client.put(
@@ -504,6 +505,7 @@ def test_update_organization_by_id_without_logo(
     db.add(org)
     db.commit()
     db.refresh(org)
+    assert org.id is not None
 
     new_name = random_lower_string()
     response = client.put(
@@ -527,6 +529,7 @@ def test_update_organization_by_id_logo_replaces_old(
     db.add(org)
     db.commit()
     db.refresh(org)
+    assert org.id is not None
 
     new_logo = create_test_image(width=150, height=150, format="PNG")
     response = client.put(
@@ -563,6 +566,7 @@ def test_update_organization_by_id_deleted_org(
     db.add(org)
     db.commit()
     db.refresh(org)
+    assert org.id is not None
 
     response = client.put(
         f"{settings.API_V1_STR}/organization/{org.id}",
@@ -582,6 +586,7 @@ def test_update_organization_by_id_is_active(
     db.add(org)
     db.commit()
     db.refresh(org)
+    assert org.id is not None
 
     response = client.put(
         f"{settings.API_V1_STR}/organization/{org.id}",
@@ -611,6 +616,7 @@ def test_update_organization_by_id_shortcode(
     db.add(org)
     db.commit()
     db.refresh(org)
+    assert org.id is not None
 
     shortcode = random_lower_string()
     response = client.put(

--- a/backend/app/tests/api/routes/test_organization.py
+++ b/backend/app/tests/api/routes/test_organization.py
@@ -516,7 +516,8 @@ def test_update_organization_by_id_without_logo(
     data = response.json()
     assert response.status_code == status.HTTP_200_OK
     assert data["name"] == new_name
-    assert data["logo"] == existing_logo
+    assert data["logo"] is not None
+    assert data["logo"].endswith(existing_logo)
 
 
 def test_update_organization_by_id_logo_replaces_old(

--- a/backend/app/tests/api/routes/test_organization.py
+++ b/backend/app/tests/api/routes/test_organization.py
@@ -70,6 +70,37 @@ def test_create_organization(
     assert data["detail"] == "User Not Permitted"
 
 
+def test_create_organization_with_logo(
+    client: TestClient,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    logo_file = create_test_image(width=200, height=200, format="PNG")
+    response = client.post(
+        f"{settings.API_V1_STR}/organization/",
+        data={"name": random_lower_string()},
+        files={"logo": ("logo.png", logo_file, "image/png")},
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["logo"] is not None
+    assert "/uploads/organizations/logos/" in data["logo"]
+
+
+def test_create_organization_without_logo(
+    client: TestClient,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    response = client.post(
+        f"{settings.API_V1_STR}/organization/",
+        data={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["logo"] is None
+
+
 def test_read_organization(
     client: TestClient,
     db: SessionDep,
@@ -417,6 +448,76 @@ def test_update_organization(
     assert data["name"] == jal_vikas.name
     assert data["id"] == jal_vikas.id
     assert data["description"] == updated_description
+
+
+def test_update_organization_by_id_with_logo(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    logo_file = create_test_image(width=200, height=200, format="PNG")
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{org.id}",
+        data={"name": random_lower_string()},
+        files={"logo": ("logo.png", logo_file, "image/png")},
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["logo"] is not None
+    assert "/uploads/organizations/logos/" in data["logo"]
+
+
+def test_update_organization_by_id_without_logo(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    existing_logo = "/uploads/organizations/logos/org_keep.png"
+    org = Organization(name=random_lower_string(), logo=existing_logo)
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    new_name = random_lower_string()
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{org.id}",
+        data={"name": new_name},
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["name"] == new_name
+    assert data["logo"] == existing_logo
+
+
+def test_update_organization_by_id_logo_replaces_old(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    old_logo = "/uploads/organizations/logos/org_old.png"
+    org = Organization(name=random_lower_string(), logo=old_logo)
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    new_logo = create_test_image(width=150, height=150, format="PNG")
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{org.id}",
+        files={"logo": ("new_logo.png", new_logo, "image/png")},
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["logo"] is not None
+    assert data["logo"] != old_logo
+    assert "/uploads/organizations/logos/" in data["logo"]
 
 
 def test_visibility_organization(

--- a/backend/app/tests/api/routes/test_organization.py
+++ b/backend/app/tests/api/routes/test_organization.py
@@ -520,6 +520,88 @@ def test_update_organization_by_id_logo_replaces_old(
     assert "/uploads/organizations/logos/" in data["logo"]
 
 
+def test_update_organization_by_id_not_found(
+    client: TestClient,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/0",
+        data={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Organization not found"
+
+
+def test_update_organization_by_id_deleted_org(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    org = Organization(name=random_lower_string(), is_deleted=True)
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{org.id}",
+        data={"name": random_lower_string()},
+        headers=get_user_superadmin_token,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Organization not found"
+
+
+def test_update_organization_by_id_is_active(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    org = Organization(name=random_lower_string(), is_active=True)
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{org.id}",
+        data={"is_active": "false"},
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["is_active"] is False
+
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{org.id}",
+        data={"is_active": "true"},
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["is_active"] is True
+
+
+def test_update_organization_by_id_shortcode(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    shortcode = random_lower_string()
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{org.id}",
+        data={"shortcode": shortcode},
+        headers=get_user_superadmin_token,
+    )
+    data = response.json()
+    assert response.status_code == status.HTTP_200_OK
+    assert data["shortcode"] == shortcode
+
+
 def test_visibility_organization(
     client: TestClient,
     db: SessionDep,

--- a/backend/app/tests/api/routes/test_organization.py
+++ b/backend/app/tests/api/routes/test_organization.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 from sqlmodel import select
@@ -85,6 +88,24 @@ def test_create_organization_with_logo(
     assert response.status_code == status.HTTP_200_OK
     assert data["logo"] is not None
     assert "/uploads/organizations/logos/" in data["logo"]
+
+
+def test_create_organization_logo_cleanup_on_db_failure(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    logo_file = create_test_image(width=100, height=100, format="PNG")
+    with patch("app.api.routes.organization.delete_logo_file") as mock_delete:
+        with patch.object(db, "commit", side_effect=Exception("simulated DB failure")):
+            with pytest.raises(Exception, match="simulated DB failure"):
+                client.post(
+                    f"{settings.API_V1_STR}/organization/",
+                    data={"name": random_lower_string()},
+                    files={"logo": ("logo.png", logo_file, "image/png")},
+                    headers=get_user_superadmin_token,
+                )
+    mock_delete.assert_called_once()
 
 
 def test_create_organization_without_logo(

--- a/backend/app/tests/api/routes/test_organization_settings.py
+++ b/backend/app/tests/api/routes/test_organization_settings.py
@@ -110,7 +110,7 @@ def test_create_organization_initializes_settings_row(
     name = random_lower_string()
     response = client.post(
         f"{settings.API_V1_STR}/organization/",
-        json={"name": name, "description": random_lower_string()},
+        data={"name": name, "description": random_lower_string()},
         headers=get_user_superadmin_token,
     )
     assert response.status_code == 200

--- a/backend/app/tests/api/routes/test_question.py
+++ b/backend/app/tests/api/routes/test_question.py
@@ -43,7 +43,7 @@ def test_create_question(
     org_name = random_lower_string()
     org_response = client.post(
         f"{settings.API_V1_STR}/organization/",
-        json={"name": org_name},
+        data={"name": org_name},
         headers=get_user_superadmin_token,
     )
     org_data = org_response.json()
@@ -136,7 +136,7 @@ def test_create_subjective_question_with_options_should_fail(
 ) -> None:
     org_response = client.post(
         f"{settings.API_V1_STR}/organization/",
-        json={"name": random_lower_string()},
+        data={"name": random_lower_string()},
         headers=get_user_superadmin_token,
     )
     org_id = org_response.json()["id"]


### PR DESCRIPTION


Fixes: #522 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizations can upload a logo during create/update (multipart/form-data). Creation auto-initializes organization settings. Organization endpoints now return the public-facing organization representation.

* **Bug Fixes**
  * Uploaded logo files are removed on save failures; old logos deleted only after successful updates. Absolute logo/guide URLs now use HTTP for local and HTTPS otherwise.

* **Tests**
  * Added/updated tests covering logo upload, replacement, preservation, cleanup-on-failure, and various update scenarios (not-found/deleted, active toggle, shortcode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->