### PR TITLE
Preserve time spent when answer update omits timing

### DIFF
--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -940,7 +940,8 @@ def submit_answer_for_qr_candidate(
         # Update existing answer
         existing_answer.response = answer_request.response
         existing_answer.visited = answer_request.visited
-        existing_answer.time_spent = answer_request.time_spent
+        if "time_spent" in answer_request.model_fields_set:
+            existing_answer.time_spent = answer_request.time_spent
         existing_answer.bookmarked = answer_request.bookmarked
         session.add(existing_answer)
         session.commit()
@@ -1064,7 +1065,8 @@ def submit_batch_answers_for_qr_candidate(
             # Update existing answer
             existing_answer.response = answer.response
             existing_answer.visited = answer.visited
-            existing_answer.time_spent = answer.time_spent
+            if "time_spent" in answer.model_fields_set:
+                existing_answer.time_spent = answer.time_spent
             existing_answer.bookmarked = answer.bookmarked
             session.add(existing_answer)
             results.append(existing_answer)

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -3030,6 +3030,24 @@ def test_submit_answer_updates_existing(client: TestClient, db: SessionDep) -> N
     assert response2.json()["response"] == "[10]"  # Updated response
     assert response2.json()["time_spent"] == 40  # Updated time
 
+    # Updating the answer without time_spent should not clear the tracked time.
+    third_answer = {
+        "question_revision_id": question_revision.id,
+        "response": "[1]",
+        "visited": True,
+    }
+
+    response3 = client.post(
+        f"{settings.API_V1_STR}/candidate/submit_answer/{candidate_test_id}",
+        json=third_answer,
+        params={"candidate_uuid": candidate_uuid},
+    )
+
+    assert response3.status_code == 200
+    assert response3.json()["id"] == first_answer_id
+    assert response3.json()["response"] == "[1]"
+    assert response3.json()["time_spent"] == 40
+
     # Verify only one answer exists in database
     answers = db.exec(
         select(CandidateTestAnswer)
@@ -3037,7 +3055,8 @@ def test_submit_answer_updates_existing(client: TestClient, db: SessionDep) -> N
         .where(CandidateTestAnswer.question_revision_id == question_revision.id)
     ).all()
     assert len(answers) == 1
-    assert answers[0].response == "[10]"
+    assert answers[0].response == "[1]"
+    assert answers[0].time_spent == 40
 
 
 def test_get_test_result(


### PR DESCRIPTION
## Summary
- preserve existing answer time_spent when an update request omits the field
- keep explicit time_spent updates, including explicit null, supported
- add regression coverage for answer updates that change response without timing

## Why
The webapp per-question timer flow now treats answer saves and timing syncs separately. Normal answer updates may omit time_spent, while navigation/periodic sync sends timing explicitly. Without this guard, an answer-only update can wipe a previously synced time_spent value.

## Verification
- uv run ruff check app/api/routes/candidate.py app/tests/api/routes/test_candidate.py
- PROJECT_NAME='Sashakt Platform' POSTGRES_SERVER=localhost POSTGRES_USER=postgres POSTGRES_PASSWORD=password POSTGRES_DB=sashakt-app FIRST_SUPERUSER=admin@example.com FIRST_SUPERUSER_PASSWORD=changethis UPLOAD_ROOT=/tmp/app/uploads uv run pytest app/tests/api/routes/test_candidate.py -k submit_answer_updates_existing

Note: pytest needed a temporary local upload-root code override because main still hardcodes /app/uploads during app startup; that override is not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where previously recorded time spent on answers could be lost when submitting answer updates without timing information. Time spent is now correctly preserved across submissions unless explicitly changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->