### PR TITLE
Configure Test Instructions and Completion Message at Organization Level

### DIFF
--- a/backend/app/alembic/versions/fe6a2f1b6886_add_pre_test_instructions_to_org_settings.py
+++ b/backend/app/alembic/versions/fe6a2f1b6886_add_pre_test_instructions_to_org_settings.py
@@ -1,0 +1,49 @@
+"""add pre_test_instructions and completion_message to organization settings
+
+Revision ID: fe6a2f1b6886
+Revises: c2f7d9a4b8e1
+Create Date: 2026-06-10 00:00:00.000000
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "fe6a2f1b6886"
+down_revision: str = "c2f7d9a4b8e1"
+branch_labels = None
+depends_on = None
+
+# Frozen defaults — do not reference live model constants.
+_FROZEN_PRE_TEST_INSTRUCTIONS_DEFAULT = {"value": {"text": None}}
+_FROZEN_COMPLETION_MESSAGE_DEFAULT = {"value": {"text": None}}
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE organization_settings
+            SET settings = settings
+                || jsonb_build_object('pre_test_instructions', CAST(:pti AS JSONB))
+                || jsonb_build_object('completion_message', CAST(:cm AS JSONB))
+                || jsonb_build_object('version', 5)
+            """
+        ).bindparams(
+            pti=json.dumps(_FROZEN_PRE_TEST_INSTRUCTIONS_DEFAULT),
+            cm=json.dumps(_FROZEN_COMPLETION_MESSAGE_DEFAULT),
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE organization_settings
+        SET settings = (settings - 'pre_test_instructions' - 'completion_message')
+            || jsonb_build_object('version', 4)
+        """
+    )

--- a/backend/app/models/organization_settings.py
+++ b/backend/app/models/organization_settings.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from app.models.organization import Organization
 
 
-ORGANIZATION_SETTINGS_SCHEMA_VERSION = 4
+ORGANIZATION_SETTINGS_SCHEMA_VERSION = 5
 
 
 NOMENCLATURE_DEFAULTS: dict[str, str] = {
@@ -276,6 +276,40 @@ class AnalyticsLinkSetting(BaseModel):
     value: AnalyticsLinkValue = PydanticField(default_factory=AnalyticsLinkValue)
 
 
+class PreTestInstructionsValue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    text: str | None = None
+
+
+class PreTestInstructionsSetting(BaseModel):
+    """Default pre-test instructions pre-populated on the test config page.
+    Test admins can always edit or clear this value."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: PreTestInstructionsValue = PydanticField(
+        default_factory=PreTestInstructionsValue
+    )
+
+
+class CompletionMessageValue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    text: str | None = None
+
+
+class CompletionMessageSetting(BaseModel):
+    """Default completion message pre-populated on the test config page.
+    Test admins can always edit or clear this value."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: CompletionMessageValue = PydanticField(
+        default_factory=CompletionMessageValue
+    )
+
+
 class OrganizationSettingsPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -298,6 +332,12 @@ class OrganizationSettingsPayload(BaseModel):
     )
     analytics_link: AnalyticsLinkSetting = PydanticField(
         default_factory=AnalyticsLinkSetting
+    )
+    pre_test_instructions: PreTestInstructionsSetting = PydanticField(
+        default_factory=PreTestInstructionsSetting
+    )
+    completion_message: CompletionMessageSetting = PydanticField(
+        default_factory=CompletionMessageSetting
     )
 
     @field_validator("version")
@@ -346,6 +386,8 @@ def default_organization_settings() -> OrganizationSettingsPayload:
         platform_nomenclature=PlatformNomenclatureSetting(mode="default"),
         platform_guide=PlatformGuideSetting(),
         analytics_link=AnalyticsLinkSetting(),
+        pre_test_instructions=PreTestInstructionsSetting(),
+        completion_message=CompletionMessageSetting(),
     )
 
 

--- a/backend/app/tests/api/routes/test_organization_settings.py
+++ b/backend/app/tests/api/routes/test_organization_settings.py
@@ -16,6 +16,7 @@ from app.models.organization_settings import (
     ORGANIZATION_SETTINGS_SCHEMA_VERSION,
     AnswerReviewSetting,
     AnswerReviewValue,
+    CompletionMessageSetting,
     MarkForReviewSetting,
     MarkForReviewValue,
     MarkingSchemeSetting,
@@ -27,6 +28,7 @@ from app.models.organization_settings import (
     PauseTestValue,
     PlatformNomenclatureSetting,
     PlatformNomenclatureValue,
+    PreTestInstructionsSetting,
     QuestionPaletteSetting,
     QuestionPaletteValue,
     QuestionsPerPageSetting,
@@ -1566,6 +1568,151 @@ def test_put_settings_rejects_analytics_link_without_scheme(
     own_org_id = _get_org_id(client, get_user_systemadmin_token)
     payload = default_organization_settings().model_dump(mode="json")
     payload["analytics_link"]["value"]["url"] = "lookerstudio.in"
+
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+        json={"settings": payload},
+    )
+    assert response.status_code == 422
+
+
+# ---------- pre_test_instructions + completion_message ----------
+
+
+def test_default_settings_include_pre_test_instructions_and_completion_message() -> (
+    None
+):
+    payload = OrganizationSettingsPayload.model_validate(DEFAULT_ORGANIZATION_SETTINGS)
+    assert payload.pre_test_instructions.value.text is None
+    assert payload.completion_message.value.text is None
+
+
+def test_put_settings_pre_test_instructions_round_trip(
+    client: TestClient,
+    get_user_systemadmin_token: dict[str, str],
+) -> None:
+    own_org_id = _get_org_id(client, get_user_systemadmin_token)
+    payload = default_organization_settings()
+    payload.pre_test_instructions = PreTestInstructionsSetting()
+    payload.pre_test_instructions.value.text = "Read the instructions carefully."
+
+    put_resp = client.put(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+        json={"settings": payload.model_dump(mode="json")},
+    )
+    assert put_resp.status_code == 200
+
+    get_resp = client.get(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+    )
+    assert get_resp.status_code == 200
+    assert (
+        get_resp.json()["settings"]["pre_test_instructions"]["value"]["text"]
+        == "Read the instructions carefully."
+    )
+
+
+def test_put_settings_completion_message_round_trip(
+    client: TestClient,
+    get_user_systemadmin_token: dict[str, str],
+) -> None:
+    own_org_id = _get_org_id(client, get_user_systemadmin_token)
+    payload = default_organization_settings()
+    payload.completion_message = CompletionMessageSetting()
+    payload.completion_message.value.text = "Thanks for completing the test."
+
+    put_resp = client.put(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+        json={"settings": payload.model_dump(mode="json")},
+    )
+    assert put_resp.status_code == 200
+
+    get_resp = client.get(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+    )
+    assert get_resp.status_code == 200
+    assert (
+        get_resp.json()["settings"]["completion_message"]["value"]["text"]
+        == "Thanks for completing the test."
+    )
+
+
+def test_put_settings_clears_pre_test_instructions_to_null(
+    client: TestClient,
+    get_user_systemadmin_token: dict[str, str],
+) -> None:
+    own_org_id = _get_org_id(client, get_user_systemadmin_token)
+
+    payload = default_organization_settings()
+    payload.pre_test_instructions.value.text = "Initial text."
+    client.put(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+        json={"settings": payload.model_dump(mode="json")},
+    )
+
+    payload.pre_test_instructions.value.text = None
+    put_resp = client.put(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+        json={"settings": payload.model_dump(mode="json")},
+    )
+    assert put_resp.status_code == 200
+    assert put_resp.json()["settings"]["pre_test_instructions"]["value"]["text"] is None
+
+
+def test_put_settings_clears_completion_message_to_null(
+    client: TestClient,
+    get_user_systemadmin_token: dict[str, str],
+) -> None:
+    own_org_id = _get_org_id(client, get_user_systemadmin_token)
+
+    payload = default_organization_settings()
+    payload.completion_message.value.text = "Initial message."
+    client.put(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+        json={"settings": payload.model_dump(mode="json")},
+    )
+
+    payload.completion_message.value.text = None
+    put_resp = client.put(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+        json={"settings": payload.model_dump(mode="json")},
+    )
+    assert put_resp.status_code == 200
+    assert put_resp.json()["settings"]["completion_message"]["value"]["text"] is None
+
+
+def test_put_settings_pre_test_instructions_unknown_key_returns_422(
+    client: TestClient,
+    get_user_systemadmin_token: dict[str, str],
+) -> None:
+    own_org_id = _get_org_id(client, get_user_systemadmin_token)
+    payload = default_organization_settings().model_dump(mode="json")
+    payload["pre_test_instructions"] = {"value": {"content": "wrong key"}}
+
+    response = client.put(
+        f"{settings.API_V1_STR}/organization/{own_org_id}/settings",
+        headers=get_user_systemadmin_token,
+        json={"settings": payload},
+    )
+    assert response.status_code == 422
+
+
+def test_put_settings_completion_message_unknown_key_returns_422(
+    client: TestClient,
+    get_user_systemadmin_token: dict[str, str],
+) -> None:
+    own_org_id = _get_org_id(client, get_user_systemadmin_token)
+    payload = default_organization_settings().model_dump(mode="json")
+    payload["completion_message"] = {"value": {"content": "wrong key"}}
 
     response = client.put(
         f"{settings.API_V1_STR}/organization/{own_org_id}/settings",

--- a/backend/app/tests/utils/organization_settings.py
+++ b/backend/app/tests/utils/organization_settings.py
@@ -5,6 +5,7 @@ from app.crud import organization_settings as crud_settings
 from app.models.organization_settings import (
     AnswerReviewSetting,
     AnswerReviewValue,
+    CompletionMessageSetting,
     MarkForReviewSetting,
     MarkForReviewValue,
     MarkingSchemeSetting,
@@ -14,6 +15,7 @@ from app.models.organization_settings import (
     PauseTestSetting,
     PauseTestValue,
     PlatformNomenclatureSetting,
+    PreTestInstructionsSetting,
     QuestionPaletteSetting,
     QuestionPaletteValue,
     QuestionsPerPageSetting,
@@ -51,6 +53,8 @@ def flexible_settings_payload() -> OrganizationSettingsPayload:
             mode="flexible", value=PauseTestValue(default=False)
         ),
         platform_nomenclature=PlatformNomenclatureSetting(mode="default"),
+        pre_test_instructions=PreTestInstructionsSetting(),
+        completion_message=CompletionMessageSetting(),
     )
 
 


### PR DESCRIPTION
## Summary

Fixes issue: #525 
Explain the **motivation** for making this change. Does this pull request do anything other than the problem mentioned in above issue.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations can now configure custom pre-test instructions displayed before tests begin and personalized completion messages shown when tests conclude, enabling greater customization of the testing experience for participants.

* **Chores**
  * Updated organization settings schema and database structure to support new configuration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->