### PR TITLE
Candidate Answer Attempt : Partial Answer Update Support

### DIFF
--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -1110,10 +1110,9 @@ def submit_answer_for_qr_candidate(
             response=answer_request.response,
         )
 
-    if question_revision:
-        answer_request.response = validate_question_response_format(
-            answer_request.response, question_revision.question_type
-        )
+    validated_response = validate_question_response_format(
+        answer_request.response, question_revision.question_type
+    )
     # Check if answer already exists for this question
     existing_answer = session.exec(
         select(CandidateTestAnswer)
@@ -1128,7 +1127,7 @@ def submit_answer_for_qr_candidate(
         session,
         candidate_test=candidate_test,
         question_revision_id=answer_request.question_revision_id,
-        response=answer_request.response,
+        response=validated_response,
         existing_answer=existing_answer,
     )
 
@@ -1139,11 +1138,14 @@ def submit_answer_for_qr_candidate(
                 detail="Cannot modify answer after it has been reviewed",
             )
         # Update existing answer
-        existing_answer.response = answer_request.response
-        existing_answer.visited = answer_request.visited
+        if "response" in answer_request.model_fields_set:
+            existing_answer.response = validated_response
+        if "visited" in answer_request.model_fields_set:
+            existing_answer.visited = answer_request.visited
         if "time_spent" in answer_request.model_fields_set:
             existing_answer.time_spent = answer_request.time_spent
-        existing_answer.bookmarked = answer_request.bookmarked
+        if "bookmarked" in answer_request.model_fields_set:
+            existing_answer.bookmarked = answer_request.bookmarked
         session.add(existing_answer)
         session.commit()
         session.refresh(existing_answer)
@@ -1153,7 +1155,7 @@ def submit_answer_for_qr_candidate(
         candidate_test_answer = CandidateTestAnswer(
             candidate_test_id=candidate_test_id,
             question_revision_id=answer_request.question_revision_id,
-            response=answer_request.response,
+            response=validated_response,
             visited=answer_request.visited,
             time_spent=answer_request.time_spent,
             bookmarked=answer_request.bookmarked,

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -114,7 +114,7 @@ class CandidateAnswerSubmitRequest(SQLModel):
 
     question_revision_id: int
     response: str | None = None
-    visited: bool = False
+    visited: bool = True
     time_spent: int | None = None
     bookmarked: bool = False
 

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -16904,3 +16904,163 @@ def test_submit_test_returns_admin_id(client: TestClient, db: SessionDep) -> Non
     )
     assert response.status_code == 200
     assert response.json()["admin_id"] == user.id
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by the partial-update test cases below
+# ---------------------------------------------------------------------------
+
+
+def _setup_candidate_test_with_single_choice_question(
+    client: TestClient, db: SessionDep
+) -> tuple[int, str, int]:
+    """
+    Creates a test with one single-choice question, starts the test, and
+    returns (candidate_test_id, candidate_uuid, question_revision_id).
+    """
+    user = create_random_user(db)
+
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+
+    question = Question(organization_id=org.id)
+    db.add(question)
+    db.flush()
+
+    question_revision = QuestionRevision(
+        question_id=question.id,
+        created_by_id=user.id,
+        question_text="What is 2+2?",
+        question_type=QuestionType.single_choice,
+        options=[
+            {"id": 1, "key": "A", "value": "4"},
+            {"id": 2, "key": "B", "value": "5"},
+        ],
+        correct_answer=[1],
+    )
+    db.add(question_revision)
+    db.flush()
+
+    question.last_revision_id = question_revision.id
+    db.commit()
+    db.refresh(question_revision)
+
+    from app.models.test import TestQuestion
+
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        link=random_lower_string(),
+    )
+    db.add(test)
+    db.commit()
+
+    db.add(TestQuestion(test_id=test.id, question_revision_id=question_revision.id))
+    db.commit()
+
+    test_link = get_test_link(db, test_id=test.id, admin_id=test.created_by_id)
+    start = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        json={"test_link_uuid": test_link.uuid},
+    )
+    assert start.status_code == 200
+    data = start.json()
+    return data["candidate_test_id"], data["candidate_uuid"], question_revision.id
+
+
+def test_submit_answer_time_only_preserves_response(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Sending only time_spent (no response key) must not overwrite the saved response."""
+    candidate_test_id, candidate_uuid, qr_id = (
+        _setup_candidate_test_with_single_choice_question(client, db)
+    )
+    url = f"{settings.API_V1_STR}/candidate/submit_answer/{candidate_test_id}"
+    params = {"candidate_uuid": candidate_uuid}
+
+    r = client.post(
+        url,
+        json={"question_revision_id": qr_id, "response": "[1]", "time_spent": 10},
+        params=params,
+    )
+    assert r.status_code == 200
+
+    r = client.post(
+        url, json={"question_revision_id": qr_id, "time_spent": 99}, params=params
+    )
+    assert r.status_code == 200
+    assert r.json()["response"] == "[1]"
+    assert r.json()["time_spent"] == 99
+    assert r.json()["visited"] is True
+
+
+def test_submit_answer_bookmarked_only_preserves_response(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Sending only bookmarked (no response key) must not overwrite the saved response."""
+    candidate_test_id, candidate_uuid, qr_id = (
+        _setup_candidate_test_with_single_choice_question(client, db)
+    )
+    url = f"{settings.API_V1_STR}/candidate/submit_answer/{candidate_test_id}"
+    params = {"candidate_uuid": candidate_uuid}
+
+    r = client.post(
+        url, json={"question_revision_id": qr_id, "response": "[1]"}, params=params
+    )
+    assert r.status_code == 200
+
+    r = client.post(
+        url, json={"question_revision_id": qr_id, "bookmarked": True}, params=params
+    )
+    assert r.status_code == 200
+    assert r.json()["response"] == "[1]"
+    assert r.json()["bookmarked"] is True
+    assert r.json()["visited"] is True
+
+
+def test_submit_answer_explicit_null_response_clears_it(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Sending response=null explicitly must clear the saved response."""
+    candidate_test_id, candidate_uuid, qr_id = (
+        _setup_candidate_test_with_single_choice_question(client, db)
+    )
+    url = f"{settings.API_V1_STR}/candidate/submit_answer/{candidate_test_id}"
+    params = {"candidate_uuid": candidate_uuid}
+
+    r = client.post(
+        url, json={"question_revision_id": qr_id, "response": "[1]"}, params=params
+    )
+    assert r.status_code == 200
+
+    r = client.post(
+        url, json={"question_revision_id": qr_id, "response": None}, params=params
+    )
+    assert r.status_code == 200
+    assert r.json()["response"] is None
+    assert r.json()["visited"] is True
+
+
+def test_submit_answer_visited_defaults_to_true(
+    client: TestClient, db: SessionDep
+) -> None:
+    """visited defaults to True — omitting it on create and update still yields True."""
+    candidate_test_id, candidate_uuid, qr_id = (
+        _setup_candidate_test_with_single_choice_question(client, db)
+    )
+    url = f"{settings.API_V1_STR}/candidate/submit_answer/{candidate_test_id}"
+    params = {"candidate_uuid": candidate_uuid}
+
+    # Create without visited
+    r = client.post(url, json={"question_revision_id": qr_id}, params=params)
+    assert r.status_code == 200
+    assert r.json()["visited"] is True
+
+    # Update without visited — preserved as True
+    r = client.post(
+        url, json={"question_revision_id": qr_id, "time_spent": 5}, params=params
+    )
+    assert r.status_code == 200
+    assert r.json()["visited"] is True

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -1829,7 +1829,6 @@ def test_get_test_questions(client: TestClient, db: SessionDep) -> None:
     db.commit()
 
     # Link question to test
-    from app.models.test import TestQuestion
 
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
@@ -2304,7 +2303,6 @@ def test_submit_answer_for_qr_candidate(client: TestClient, db: SessionDep) -> N
     db.commit()
 
     # Link question to test
-    from app.models.test import TestQuestion
 
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
@@ -3004,8 +3002,6 @@ def test_submit_answer_for_subjective_qr_candidate(
     db.add(test)
     db.commit()
 
-    from app.models.test import TestQuestion
-
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
     )
@@ -3127,8 +3123,6 @@ def test_update_answer_for_qr_candidate(client: TestClient, db: SessionDep) -> N
     )
     db.add(test)
     db.commit()
-
-    from app.models.test import TestQuestion
 
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
@@ -3683,8 +3677,6 @@ def test_submit_answer_updates_existing(client: TestClient, db: SessionDep) -> N
     )
     db.add(test)
     db.commit()
-
-    from app.models.test import TestQuestion
 
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
@@ -10178,8 +10170,6 @@ def test_submit_answer_for_single_choice_with_multiple_options_should_fail(
     db.add(test)
     db.commit()
 
-    from app.models.test import TestQuestion
-
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
     )
@@ -10327,8 +10317,6 @@ def test_submit_answer_for_multi_choice_with_invalid_response_should_fail(
     )
     db.add(test)
     db.commit()
-
-    from app.models.test import TestQuestion
 
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
@@ -10543,7 +10531,6 @@ def test_question_level_marking_scheme_applied_on_questions(
     db.commit()
 
     # Link the question to the test
-    from app.models.test import TestQuestion
 
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
@@ -16846,8 +16833,6 @@ def test_get_test_questions_returns_link(client: TestClient, db: SessionDep) -> 
     )
     db.add(test)
     db.commit()
-
-    from app.models.test import TestQuestion
 
     db.add(TestQuestion(test_id=test.id, question_revision_id=question_revision.id))
     db.commit()

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -16946,8 +16946,6 @@ def _setup_candidate_test_with_single_choice_question(
     db.commit()
     db.refresh(question_revision)
 
-    from app.models.test import TestQuestion
-
     test = Test(
         name=random_lower_string(),
         created_by_id=user.id,

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -16965,7 +16965,12 @@ def _setup_candidate_test_with_single_choice_question(
     )
     assert start.status_code == 200
     data = start.json()
-    return data["candidate_test_id"], data["candidate_uuid"], question_revision.id
+    assert question_revision.id is not None
+    return (
+        int(data["candidate_test_id"]),
+        str(data["candidate_uuid"]),
+        question_revision.id,
+    )
 
 
 def test_submit_answer_time_only_preserves_response(

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -1829,7 +1829,6 @@ def test_get_test_questions(client: TestClient, db: SessionDep) -> None:
     db.commit()
 
     # Link question to test
-
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
     )
@@ -2303,7 +2302,6 @@ def test_submit_answer_for_qr_candidate(client: TestClient, db: SessionDep) -> N
     db.commit()
 
     # Link question to test
-
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
     )
@@ -10445,7 +10443,6 @@ def test_test_level_marking_scheme_applied_on_questions(
     db.commit()
 
     # Link question to test
-
     test_question = TestQuestion(
         test_id=test.id, question_revision_id=question_revision.id
     )


### PR DESCRIPTION
## Summary

Fixes issue: #548 


## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Candidate answer submissions now consistently validate responses before saving and enforcing attempt limits.
  * Partial updates preserve existing responses and status flags unless explicitly changed.
  * Explicitly submitting `null` clears a saved response.
  * When omitted, `visited` now defaults to `true`.
* **Tests**
  * Added coverage for partial updates, response clearing, and default visit status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->