### PR TITLE
Add certificate download URL generation

### DIFF
--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -2022,6 +2022,73 @@ def convert_to_list(value: object) -> list[str]:
     return [str(value)]
 
 
+def get_or_create_certificate_download_url(
+    session: SessionDep,
+    candidate_test: CandidateTest,
+    test: Test,
+    result: Result,
+) -> str | None:
+    """Get the certificate download URL for a candidate test.
+
+    Reuses the token in `candidate_test.certificate_data` if one was already
+    generated; otherwise generates a new token and persists a certificate
+    data snapshot (candidate_test is added to the session but not committed
+    here - the caller is responsible for committing). Returns None if the
+    test has no certificate configured.
+    """
+    if not test.certificate_id:
+        return None
+
+    if candidate_test.certificate_data and candidate_test.certificate_data.get("token"):
+        token = candidate_test.certificate_data["token"]
+        return f"/api/v1/certificate/download/{token}"
+
+    token = generate_certificate_token()
+
+    raw_marks_obtained = result.marks_obtained or 0.0
+    raw_marks_maximum = result.marks_maximum or 0.0
+    if raw_marks_maximum > 0:
+        score_percentage = raw_marks_obtained / raw_marks_maximum * 100
+        score_str = f"{raw_marks_obtained:.1f}/{raw_marks_maximum:.1f} ({score_percentage:.1f}%)"
+    else:
+        score_str = "N/A"
+
+    completion_date = (
+        candidate_test.end_time.strftime("%B %d, %Y")
+        if candidate_test.end_time
+        else "N/A"
+    )
+
+    form_response_data: dict[str, Any] = {}
+    if test.form_id:
+        raw_responses: dict[str, Any] = {}
+        form_response = session.exec(
+            select(FormResponse).where(
+                FormResponse.candidate_test_id == candidate_test.id,
+                FormResponse.form_id == test.form_id,
+            )
+        ).first()
+        if form_response and form_response.responses:
+            raw_responses = form_response.responses
+
+        form_response_data = resolve_form_response_values(
+            form_id=test.form_id,
+            responses=raw_responses,
+            session=session,
+        )
+
+    candidate_test.certificate_data = {
+        "token": token,
+        "test_name": test.name,
+        "score": score_str,
+        "completion_date": completion_date,
+        **form_response_data,
+    }
+    session.add(candidate_test)
+
+    return f"/api/v1/certificate/download/{token}"
+
+
 def compute_result(
     session: SessionDep,
     candidate_test: CandidateTest,
@@ -2295,68 +2362,10 @@ def get_test_result(
     result = compute_result(
         session, candidate_test, test, question_sets_by_id, sectioned
     )
-
-    certificate_download_url = None
-    if test.certificate_id:
-        # Check if certificate_data already exists (reuse token)
-        if candidate_test.certificate_data and candidate_test.certificate_data.get(
-            "token"
-        ):
-            token = candidate_test.certificate_data["token"]
-        else:
-            # Generate new token and save certificate data snapshot
-            token = generate_certificate_token()
-
-            raw_marks_obtained = result.marks_obtained or 0.0
-            raw_marks_maximum = result.marks_maximum or 0.0
-            if raw_marks_maximum > 0:
-                score_percentage = raw_marks_obtained / raw_marks_maximum * 100
-                score_str = f"{raw_marks_obtained:.1f}/{raw_marks_maximum:.1f} ({score_percentage:.1f}%)"
-            else:
-                score_str = "N/A"
-
-            # Format completion date
-            completion_date = (
-                candidate_test.end_time.strftime("%B %d, %Y")
-                if candidate_test.end_time
-                else "N/A"
-            )
-
-            # Get form response values if available
-            form_response_data: dict[str, Any] = {}
-            if test.form_id:
-                raw_responses: dict[str, Any] = {}
-                form_response = session.exec(
-                    select(FormResponse).where(
-                        FormResponse.candidate_test_id == candidate_test.id,
-                        FormResponse.form_id == test.form_id,
-                    )
-                ).first()
-                if form_response and form_response.responses:
-                    raw_responses = form_response.responses
-                # Always resolve so unanswered fields default to "N/A"
-                form_response_data = resolve_form_response_values(
-                    form_id=test.form_id,
-                    responses=raw_responses,
-                    session=session,
-                )
-
-            # Save certificate data snapshot (fixed tokens + form field values)
-            candidate_test.certificate_data = {
-                "token": token,
-                # Fixed tokens
-                "test_name": test.name,
-                "score": score_str,
-                "completion_date": completion_date,
-                # Dynamic tokens from form response
-                **form_response_data,
-            }
-            session.add(candidate_test)
-            session.commit()
-
-        certificate_download_url = f"/api/v1/certificate/download/{token}"
-
-    result.certificate_download_url = certificate_download_url
+    result.certificate_download_url = get_or_create_certificate_download_url(
+        session, candidate_test, test, result
+    )
+    session.commit()
     return result
 
 

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -2081,11 +2081,11 @@ def get_or_create_certificate_download_url(
         )
 
     candidate_test.certificate_data = {
+        **form_response_data,
         "token": token,
         "test_name": test.name,
         "score": score_str,
         "completion_date": completion_date,
-        **form_response_data,
     }
     session.add(candidate_test)
 

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -2027,6 +2027,7 @@ def get_or_create_certificate_download_url(
     candidate_test: CandidateTest,
     test: Test,
     result: Result,
+    resolved_form_response: dict[str, Any] | None = None,
 ) -> str | None:
     """Get the certificate download URL for a candidate test.
 
@@ -2060,7 +2061,9 @@ def get_or_create_certificate_download_url(
     )
 
     form_response_data: dict[str, Any] = {}
-    if test.form_id:
+    if resolved_form_response is not None:
+        form_response_data = resolved_form_response
+    elif test.form_id:
         raw_responses: dict[str, Any] = {}
         form_response = session.exec(
             select(FormResponse).where(

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -16,7 +16,10 @@ from app.api.deps import (
     SessionDep,
     permission_dependency,
 )
-from app.api.routes.candidate import compute_result
+from app.api.routes.candidate import (
+    compute_result,
+    get_or_create_certificate_download_url,
+)
 from app.api.routes.utils import get_current_time
 from app.core.candidate import get_time_taken_seconds
 from app.core.question_sets import is_sectioned_test
@@ -51,7 +54,7 @@ from app.models.candidate import (
     CandidateTestAnswer,
     Result,
 )
-from app.models.form import Form, FormFieldPublic, FormPublic
+from app.models.form import Form, FormFieldPublic, FormPublic, FormResponse
 from app.models.location import District
 from app.models.role import Role
 from app.models.tag import Tag, TagPublic
@@ -71,6 +74,7 @@ from app.models.test import (
 )
 from app.models.user import User
 from app.models.utils import TimeLeft
+from app.services.certificate_tokens import resolve_form_response_values
 from app.services.organization_nomenclature import resolve_nomenclature_for_test
 from app.services.organization_settings_mapper import (
     fixed_overrides_for_test,
@@ -103,7 +107,27 @@ def transform_to_report(
         if candidate.id is not None
     }
 
+    candidate_test_ids = [
+        candidate_test.id
+        for candidate_test in candidate_test_list
+        if candidate_test.id is not None
+    ]
+    raw_form_responses_by_candidate_test: dict[int, dict[str, Any]] = {}
+    if test.form_id and candidate_test_ids:
+        form_response_rows = session.exec(
+            select(FormResponse).where(
+                col(FormResponse.candidate_test_id).in_(candidate_test_ids),
+                FormResponse.form_id == test.form_id,
+            )
+        ).all()
+        raw_form_responses_by_candidate_test = {
+            form_response.candidate_test_id: form_response.responses
+            for form_response in form_response_rows
+            if form_response.responses
+        }
+
     report_entries: list[CandidateReport] = []
+    certificate_data_changed = False
     for candidate_test in candidate_test_list:
         candidate = candidates_by_id.get(candidate_test.candidate_id)
         if candidate and candidate.identity:
@@ -121,6 +145,30 @@ def transform_to_report(
                     question_sets_by_id,
                     sectioned,
                 )
+                had_token = bool(
+                    candidate_test.certificate_data
+                    and candidate_test.certificate_data.get("token")
+                )
+                result.certificate_download_url = (
+                    get_or_create_certificate_download_url(
+                        session, candidate_test, test, result
+                    )
+                )
+                if not had_token and result.certificate_download_url:
+                    certificate_data_changed = True
+
+            form_response: dict[str, Any] | None = None
+            raw_responses = (
+                raw_form_responses_by_candidate_test.get(candidate_test.id)
+                if candidate_test.id is not None
+                else None
+            )
+            if test.form_id and raw_responses:
+                form_response = resolve_form_response_values(
+                    form_id=test.form_id,
+                    responses=raw_responses,
+                    session=session,
+                )
 
             report_entries.append(
                 CandidateReport(
@@ -131,8 +179,12 @@ def transform_to_report(
                     end_time=candidate_test.end_time,
                     time_taken_seconds=get_time_taken_seconds(candidate_test),
                     result=result,
+                    form_response=form_response,
                 )
             )
+
+    if certificate_data_changed:
+        session.commit()
     return report_entries
 
 

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -136,6 +136,19 @@ def transform_to_report(
             else:
                 status = CandidateReportStatus.not_submitted
 
+            form_response: dict[str, Any] | None = None
+            raw_responses = (
+                raw_form_responses_by_candidate_test.get(candidate_test.id)
+                if candidate_test.id is not None
+                else None
+            )
+            if test.form_id and raw_responses:
+                form_response = resolve_form_response_values(
+                    form_id=test.form_id,
+                    responses=raw_responses,
+                    session=session,
+                )
+
             result: Result | None = None
             if candidate_test.start_time and candidate_test.end_time:
                 result = compute_result(
@@ -151,24 +164,15 @@ def transform_to_report(
                 )
                 result.certificate_download_url = (
                     get_or_create_certificate_download_url(
-                        session, candidate_test, test, result
+                        session,
+                        candidate_test,
+                        test,
+                        result,
+                        resolved_form_response=form_response,
                     )
                 )
                 if not had_token and result.certificate_download_url:
                     certificate_data_changed = True
-
-            form_response: dict[str, Any] | None = None
-            raw_responses = (
-                raw_form_responses_by_candidate_test.get(candidate_test.id)
-                if candidate_test.id is not None
-                else None
-            )
-            if test.form_id and raw_responses:
-                form_response = resolve_form_response_values(
-                    form_id=test.form_id,
-                    responses=raw_responses,
-                    session=session,
-                )
 
             report_entries.append(
                 CandidateReport(

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -377,6 +377,7 @@ class CandidateReport(SQLModel):
     end_time: datetime | None = None
     time_taken_seconds: int | None = None
     result: Result | None = None
+    form_response: dict[str, Any] | None = None
 
 
 class CandidateReportResponse(SQLModel):

--- a/backend/app/tests/api/routes/test_candidate_report.py
+++ b/backend/app/tests/api/routes/test_candidate_report.py
@@ -6,6 +6,8 @@ from app.api.deps import SessionDep
 from app.core.config import settings
 from app.models import TestQuestion
 from app.models.candidate import CandidateTestAnswer
+from app.models.certificate import Certificate
+from app.models.form import Form, FormField, FormFieldType, FormResponse
 from app.tests.utils.candidate import (
     create_test_candidate,
     create_test_candidate_test,
@@ -13,6 +15,7 @@ from app.tests.utils.candidate import (
 )
 from app.tests.utils.question_revisions import create_random_question_revision
 from app.tests.utils.user import create_random_user, get_org_user
+from app.tests.utils.utils import random_lower_string
 
 
 def test_candidate_report_submitted(
@@ -666,3 +669,599 @@ def test_candidate_report_sort_by_invalid_field(
     )
 
     assert response.status_code == 400
+
+
+def test_candidate_report_certificate_download_url_present(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """Report includes a certificate_download_url for a submitted candidate when the
+    test has a certificate assigned, and persists the certificate data snapshot."""
+    user = get_org_user(client, db, get_user_superadmin_token)
+
+    certificate = Certificate(
+        name=random_lower_string(),
+        description=random_lower_string(),
+        organization_id=user.organization_id,
+        created_by_id=user.id,
+        url=random_lower_string(),
+    )
+    db.add(certificate)
+    db.commit()
+    db.refresh(certificate)
+
+    revision = create_random_question_revision(
+        db,
+        user_id=user.id,
+        org_id=user.organization_id,
+        marking_scheme={"correct": 10, "wrong": 0, "skipped": 0},
+    )
+
+    test = create_test_record(
+        db,
+        user_id=user.id,
+        organization_id=user.organization_id,
+        marks_level="question",
+    )
+    test.certificate_id = certificate.id
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+
+    db.add(TestQuestion(test_id=test.id, question_revision_id=revision.id))
+    db.commit()
+
+    candidate = create_test_candidate(db, organization_id=user.organization_id)
+    candidate.identity = uuid.uuid4()
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    candidate_test = create_test_candidate_test(
+        db,
+        admin_id=user.id,
+        test_id=test.id,
+        candidate_id=candidate.id,
+        question_revision_ids=[revision.id],
+        is_submitted=True,
+        end_time="2026-06-10T10:32:00",
+    )
+
+    db.add(
+        CandidateTestAnswer(
+            candidate_test_id=candidate_test.id,
+            question_revision_id=revision.id,
+            response="[1]",
+            visited=True,
+        )
+    )
+    db.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/test/{test.id}/candidate-report",
+        headers=get_user_superadmin_token,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 1
+
+    entry = data["items"][0]
+    assert entry["result"]["certificate_download_url"] is not None
+    assert entry["result"]["certificate_download_url"].startswith(
+        "/api/v1/certificate/download/"
+    )
+
+    db.refresh(candidate_test)
+    assert candidate_test.certificate_data is not None
+    assert candidate_test.certificate_data.get("token") is not None
+
+
+def test_candidate_report_certificate_download_url_none_without_certificate(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """Report has certificate_download_url=None when the test has no certificate."""
+    user = get_org_user(client, db, get_user_superadmin_token)
+
+    revision = create_random_question_revision(
+        db,
+        user_id=user.id,
+        org_id=user.organization_id,
+        marking_scheme={"correct": 10, "wrong": 0, "skipped": 0},
+    )
+
+    test = create_test_record(
+        db,
+        user_id=user.id,
+        organization_id=user.organization_id,
+        marks_level="question",
+    )
+
+    db.add(TestQuestion(test_id=test.id, question_revision_id=revision.id))
+    db.commit()
+
+    candidate = create_test_candidate(db, organization_id=user.organization_id)
+    candidate.identity = uuid.uuid4()
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    candidate_test = create_test_candidate_test(
+        db,
+        admin_id=user.id,
+        test_id=test.id,
+        candidate_id=candidate.id,
+        question_revision_ids=[revision.id],
+        is_submitted=True,
+        end_time="2026-06-10T10:32:00",
+    )
+
+    db.add(
+        CandidateTestAnswer(
+            candidate_test_id=candidate_test.id,
+            question_revision_id=revision.id,
+            response="[1]",
+            visited=True,
+        )
+    )
+    db.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/test/{test.id}/candidate-report",
+        headers=get_user_superadmin_token,
+    )
+
+    assert response.status_code == 200
+    entry = response.json()["items"][0]
+    assert entry["result"]["certificate_download_url"] is None
+
+    db.refresh(candidate_test)
+    assert candidate_test.certificate_data is None
+
+
+def test_candidate_report_certificate_token_reused_across_calls(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """Calling the report endpoint twice returns the same certificate token/url
+    instead of regenerating it each time."""
+    user = get_org_user(client, db, get_user_superadmin_token)
+
+    certificate = Certificate(
+        name=random_lower_string(),
+        description=random_lower_string(),
+        organization_id=user.organization_id,
+        created_by_id=user.id,
+        url=random_lower_string(),
+    )
+    db.add(certificate)
+    db.commit()
+    db.refresh(certificate)
+
+    revision = create_random_question_revision(
+        db,
+        user_id=user.id,
+        org_id=user.organization_id,
+        marking_scheme={"correct": 10, "wrong": 0, "skipped": 0},
+    )
+
+    test = create_test_record(
+        db,
+        user_id=user.id,
+        organization_id=user.organization_id,
+        marks_level="question",
+    )
+    test.certificate_id = certificate.id
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+
+    db.add(TestQuestion(test_id=test.id, question_revision_id=revision.id))
+    db.commit()
+
+    candidate = create_test_candidate(db, organization_id=user.organization_id)
+    candidate.identity = uuid.uuid4()
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    candidate_test = create_test_candidate_test(
+        db,
+        admin_id=user.id,
+        test_id=test.id,
+        candidate_id=candidate.id,
+        question_revision_ids=[revision.id],
+        is_submitted=True,
+        end_time="2026-06-10T10:32:00",
+    )
+
+    db.add(
+        CandidateTestAnswer(
+            candidate_test_id=candidate_test.id,
+            question_revision_id=revision.id,
+            response="[1]",
+            visited=True,
+        )
+    )
+    db.commit()
+
+    first_response = client.get(
+        f"{settings.API_V1_STR}/test/{test.id}/candidate-report",
+        headers=get_user_superadmin_token,
+    )
+    second_response = client.get(
+        f"{settings.API_V1_STR}/test/{test.id}/candidate-report",
+        headers=get_user_superadmin_token,
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+
+    first_url = first_response.json()["items"][0]["result"]["certificate_download_url"]
+    second_url = second_response.json()["items"][0]["result"][
+        "certificate_download_url"
+    ]
+
+    assert first_url is not None
+    assert first_url == second_url
+
+
+def test_candidate_report_certificate_generated_independently_per_candidate(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """Each candidate in the same report page gets its own distinct certificate
+    token, and both are persisted."""
+    user = get_org_user(client, db, get_user_superadmin_token)
+
+    certificate = Certificate(
+        name=random_lower_string(),
+        description=random_lower_string(),
+        organization_id=user.organization_id,
+        created_by_id=user.id,
+        url=random_lower_string(),
+    )
+    db.add(certificate)
+    db.commit()
+    db.refresh(certificate)
+
+    revision = create_random_question_revision(
+        db,
+        user_id=user.id,
+        org_id=user.organization_id,
+        marking_scheme={"correct": 10, "wrong": 0, "skipped": 0},
+    )
+
+    test = create_test_record(
+        db,
+        user_id=user.id,
+        organization_id=user.organization_id,
+        marks_level="question",
+    )
+    test.certificate_id = certificate.id
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+
+    db.add(TestQuestion(test_id=test.id, question_revision_id=revision.id))
+    db.commit()
+
+    candidate_tests = []
+    for _ in range(2):
+        candidate = create_test_candidate(db, organization_id=user.organization_id)
+        candidate.identity = uuid.uuid4()
+        db.add(candidate)
+        db.commit()
+        db.refresh(candidate)
+
+        candidate_test = create_test_candidate_test(
+            db,
+            admin_id=user.id,
+            test_id=test.id,
+            candidate_id=candidate.id,
+            question_revision_ids=[revision.id],
+            is_submitted=True,
+            end_time="2026-06-10T10:32:00",
+        )
+        db.add(
+            CandidateTestAnswer(
+                candidate_test_id=candidate_test.id,
+                question_revision_id=revision.id,
+                response="[1]",
+                visited=True,
+            )
+        )
+        db.commit()
+        candidate_tests.append(candidate_test)
+
+    response = client.get(
+        f"{settings.API_V1_STR}/test/{test.id}/candidate-report",
+        headers=get_user_superadmin_token,
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 2
+
+    urls = {item["result"]["certificate_download_url"] for item in items}
+    assert len(urls) == 2
+    assert all(url is not None for url in urls)
+
+    for candidate_test in candidate_tests:
+        db.refresh(candidate_test)
+        assert candidate_test.certificate_data is not None
+        assert candidate_test.certificate_data.get("token") is not None
+
+
+def test_candidate_report_certificate_token_matches_single_result_endpoint(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """A certificate token generated via the single-candidate result endpoint is
+    reused (not regenerated) by the bulk candidate-report endpoint."""
+    user = get_org_user(client, db, get_user_superadmin_token)
+
+    certificate = Certificate(
+        name=random_lower_string(),
+        description=random_lower_string(),
+        organization_id=user.organization_id,
+        created_by_id=user.id,
+        url=random_lower_string(),
+    )
+    db.add(certificate)
+    db.commit()
+    db.refresh(certificate)
+
+    revision = create_random_question_revision(
+        db,
+        user_id=user.id,
+        org_id=user.organization_id,
+        marking_scheme={"correct": 10, "wrong": 0, "skipped": 0},
+    )
+
+    test = create_test_record(
+        db,
+        user_id=user.id,
+        organization_id=user.organization_id,
+        marks_level="question",
+    )
+    test.certificate_id = certificate.id
+    test.show_result = True
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+
+    db.add(TestQuestion(test_id=test.id, question_revision_id=revision.id))
+    db.commit()
+
+    candidate = create_test_candidate(db, organization_id=user.organization_id)
+    candidate.identity = uuid.uuid4()
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    candidate_test = create_test_candidate_test(
+        db,
+        admin_id=user.id,
+        test_id=test.id,
+        candidate_id=candidate.id,
+        question_revision_ids=[revision.id],
+        is_submitted=True,
+        end_time="2026-06-10T10:32:00",
+    )
+    db.add(
+        CandidateTestAnswer(
+            candidate_test_id=candidate_test.id,
+            question_revision_id=revision.id,
+            response="[1]",
+            visited=True,
+        )
+    )
+    db.commit()
+
+    result_response = client.get(
+        f"{settings.API_V1_STR}/candidate/result/{candidate_test.id}",
+        params={"candidate_uuid": str(candidate.identity)},
+    )
+    assert result_response.status_code == 200
+    single_url = result_response.json()["certificate_download_url"]
+    assert single_url is not None
+
+    report_response = client.get(
+        f"{settings.API_V1_STR}/test/{test.id}/candidate-report",
+        headers=get_user_superadmin_token,
+    )
+    assert report_response.status_code == 200
+    report_url = report_response.json()["items"][0]["result"][
+        "certificate_download_url"
+    ]
+
+    assert report_url == single_url
+
+
+def test_candidate_report_includes_form_response(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """Report includes resolved form_response values for a candidate that has
+    submitted a form response, even when the candidate has not finished the test."""
+    user = get_org_user(client, db, get_user_superadmin_token)
+
+    form = Form(
+        name=random_lower_string(),
+        organization_id=user.organization_id,
+        created_by_id=user.id,
+    )
+    db.add(form)
+    db.commit()
+    db.refresh(form)
+
+    field = FormField(
+        form_id=form.id,
+        field_type=FormFieldType.TEXT,
+        label="Full Name",
+        name="full_name",
+        order=0,
+    )
+    db.add(field)
+    db.commit()
+    db.refresh(field)
+
+    test = create_test_record(
+        db,
+        user_id=user.id,
+        organization_id=user.organization_id,
+        form_id=form.id,
+    )
+
+    candidate = create_test_candidate(db, organization_id=user.organization_id)
+    candidate.identity = uuid.uuid4()
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    candidate_test = create_test_candidate_test(
+        db,
+        admin_id=user.id,
+        test_id=test.id,
+        candidate_id=candidate.id,
+        is_submitted=False,
+        end_time=None,
+    )
+
+    db.add(
+        FormResponse(
+            candidate_test_id=candidate_test.id,
+            form_id=form.id,
+            responses={"full_name": "Jane Doe"},
+        )
+    )
+    db.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/test/{test.id}/candidate-report",
+        headers=get_user_superadmin_token,
+    )
+
+    assert response.status_code == 200
+    entry = response.json()["items"][0]
+    assert entry["status"] == "not_submitted"
+    assert entry["result"] is None
+    assert entry["form_response"] == {"full_name": "Jane Doe"}
+
+
+def test_candidate_report_form_response_none_without_submission(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """Report has form_response=None when the test has a form but the candidate
+    has not submitted any form response."""
+    user = get_org_user(client, db, get_user_superadmin_token)
+
+    form = Form(
+        name=random_lower_string(),
+        organization_id=user.organization_id,
+        created_by_id=user.id,
+    )
+    db.add(form)
+    db.commit()
+    db.refresh(form)
+
+    test = create_test_record(
+        db,
+        user_id=user.id,
+        organization_id=user.organization_id,
+        form_id=form.id,
+    )
+
+    candidate = create_test_candidate(db, organization_id=user.organization_id)
+    candidate.identity = uuid.uuid4()
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    create_test_candidate_test(
+        db,
+        admin_id=user.id,
+        test_id=test.id,
+        candidate_id=candidate.id,
+        is_submitted=False,
+        end_time=None,
+    )
+
+    response = client.get(
+        f"{settings.API_V1_STR}/test/{test.id}/candidate-report",
+        headers=get_user_superadmin_token,
+    )
+
+    assert response.status_code == 200
+    entry = response.json()["items"][0]
+    assert entry["form_response"] is None
+
+
+def test_candidate_report_form_response_none_when_test_has_no_form(
+    client: TestClient,
+    db: SessionDep,
+    get_user_superadmin_token: dict[str, str],
+) -> None:
+    """Report has form_response=None when the test has no form configured."""
+    user = get_org_user(client, db, get_user_superadmin_token)
+
+    revision = create_random_question_revision(
+        db,
+        user_id=user.id,
+        org_id=user.organization_id,
+        marking_scheme={"correct": 10, "wrong": 0, "skipped": 0},
+    )
+
+    test = create_test_record(
+        db,
+        user_id=user.id,
+        organization_id=user.organization_id,
+        marks_level="question",
+    )
+
+    db.add(TestQuestion(test_id=test.id, question_revision_id=revision.id))
+    db.commit()
+
+    candidate = create_test_candidate(db, organization_id=user.organization_id)
+    candidate.identity = uuid.uuid4()
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+
+    candidate_test = create_test_candidate_test(
+        db,
+        admin_id=user.id,
+        test_id=test.id,
+        candidate_id=candidate.id,
+        question_revision_ids=[revision.id],
+        is_submitted=True,
+        end_time="2026-06-10T10:32:00",
+    )
+    db.add(
+        CandidateTestAnswer(
+            candidate_test_id=candidate_test.id,
+            question_revision_id=revision.id,
+            response="[1]",
+            visited=True,
+        )
+    )
+    db.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/test/{test.id}/candidate-report",
+        headers=get_user_superadmin_token,
+    )
+
+    assert response.status_code == 200
+    entry = response.json()["items"][0]
+    assert entry["form_response"] is None


### PR DESCRIPTION
## Summary

Fixes : #562 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Candidate reports now include resolved `form_response` data when a candidate test has a related form submission; otherwise it’s `null`.
- **Bug Fixes**
  - Candidate certificate download links now behave consistently across repeated report requests and between bulk and single-candidate endpoints.
  - Certificate data is updated and persisted only when needed, ensuring links remain valid for future access.
  - Reports accurately reflect missing certificates and missing form responses (`null`/none when not applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->