### PR TITLE
Updating the Route for start_test

### DIFF
--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -60,7 +60,6 @@ from app.models.candidate import (
     CandidateTimerSyncRequest,
     DeleteCandidate,
     ExternalProvisionRequest,
-    ExternalStartRequest,
     OverallTestAnalyticsResponse,
     Result,
     StartTestRequest,
@@ -949,18 +948,59 @@ def _require_external_login_enabled(session: SessionDep, test: Test) -> None:
         )
 
 
+def _get_candidate_test_by_uuid(
+    session: SessionDep, test: Test, candidate_uuid: uuid.UUID
+) -> CandidateTest:
+    """Resume a previously provisioned attempt for this test.
+
+    Scoping by test_id plus the unguessable candidate identity is sufficient
+    authorization here, so unlike verify_candidate_uuid_access this does not
+    also need the candidate_test_id as a second factor.
+    """
+    candidate_test = session.exec(
+        select(CandidateTest)
+        .join(Candidate)
+        .where(CandidateTest.test_id == test.id)
+        .where(Candidate.identity == candidate_uuid)
+    ).first()
+    if not candidate_test:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Candidate test not found or invalid UUID",
+        )
+    return candidate_test
+
+
 @router.post("/start_test", response_model=StartTestResponse)
 def start_test_for_candidate(
     session: SessionDep,
     start_test_request: StartTestRequest = Body(...),
+    candidate_uuid: uuid.UUID | None = Query(
+        default=None,
+        description="Resume a previously provisioned externally-mapped attempt",
+    ),
 ) -> StartTestResponse:
     """
     Creates a candidate when they start a test, links them to the test.
     Returns the candidate UUID for verification.
+
+    If candidate_uuid is provided, resumes an existing externally-provisioned
+    attempt (see /external/provision) instead of creating a new anonymous one.
     """
     test, admin_id = _resolve_active_test_link(
         session, start_test_request.test_link_uuid
     )
+
+    if candidate_uuid is not None:
+        _require_external_login_enabled(session, test)
+        _validate_test_start_window(session, test)
+        candidate_test = _get_candidate_test_by_uuid(session, test, candidate_uuid)
+        return StartTestResponse(
+            candidate_uuid=candidate_uuid,
+            candidate_test_id=candidate_test.id,
+            is_submitted=candidate_test.is_submitted,
+        )
+
     if _should_block_anonymous_start(session, test):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -1013,32 +1053,6 @@ def provision_external_candidate_test(
     return StartTestResponse(
         candidate_uuid=candidate.identity,
         candidate_test_id=candidate_test.id,
-        is_submitted=candidate_test.is_submitted,
-    )
-
-
-@router.post("/external/start_test", response_model=StartTestResponse)
-def start_external_candidate_test(
-    session: SessionDep,
-    start_request: ExternalStartRequest = Body(...),
-) -> StartTestResponse:
-    """Resume an externally provisioned attempt using Sashakt-owned IDs."""
-    test, _admin_id = _resolve_active_test_link(session, start_request.test_link_uuid)
-    _require_external_login_enabled(session, test)
-    _validate_test_start_window(session, test)
-
-    candidate_test = verify_candidate_uuid_access(
-        session, start_request.candidate_test_id, start_request.candidate_uuid
-    )
-    if candidate_test.test_id != test.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Candidate test not found for this test link",
-        )
-
-    return StartTestResponse(
-        candidate_uuid=start_request.candidate_uuid,
-        candidate_test_id=start_request.candidate_test_id,
         is_submitted=candidate_test.is_submitted,
     )
 

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -1028,7 +1028,7 @@ def provision_external_candidate_test(
     current_user: CurrentUser,
     provision_request: ExternalProvisionRequest = Body(...),
 ) -> StartTestResponse:
-    """Create the Sashakt candidate and attempt Avanti will map to its user."""
+    """Create the Sashakt candidate and attempt Organization will map to its user."""
     test, admin_id = _resolve_active_test_link(
         session, provision_request.test_link_uuid
     )

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -358,11 +358,6 @@ class ExternalProvisionRequest(StartTestRequest):
     external_user_id: str
 
 
-class ExternalStartRequest(StartTestRequest):
-    candidate_uuid: uuid.UUID
-    candidate_test_id: int
-
-
 class OverallTestAnalyticsResponse(SQLModel):
     total_candidates: int
     overall_score_percent: float

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -15929,11 +15929,10 @@ def test_external_provision_and_start_resume_same_attempt(
     assert candidate_test.test_id == test.id
 
     start_response = client.post(
-        f"{settings.API_V1_STR}/candidate/external/start_test",
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": provision_data["candidate_uuid"]},
         json={
             "test_link_uuid": test_link.uuid,
-            "candidate_uuid": provision_data["candidate_uuid"],
-            "candidate_test_id": provision_data["candidate_test_id"],
             "device_info": "Mobile",
         },
     )
@@ -15988,11 +15987,10 @@ def test_external_start_reports_submitted_attempt(
     db.commit()
 
     start_response = client.post(
-        f"{settings.API_V1_STR}/candidate/external/start_test",
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": provision_data["candidate_uuid"]},
         json={
             "test_link_uuid": test_link.uuid,
-            "candidate_uuid": provision_data["candidate_uuid"],
-            "candidate_test_id": provision_data["candidate_test_id"],
             "device_info": "Mobile",
         },
     )
@@ -16210,18 +16208,17 @@ def test_external_start_rejects_candidate_test_for_other_test(
     provision_data = provision_response.json()
 
     start_response = client.post(
-        f"{settings.API_V1_STR}/candidate/external/start_test",
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": provision_data["candidate_uuid"]},
         json={
             "test_link_uuid": test_b_link.uuid,
-            "candidate_uuid": provision_data["candidate_uuid"],
-            "candidate_test_id": provision_data["candidate_test_id"],
             "device_info": "Mobile",
         },
     )
 
     assert start_response.status_code == 404
     assert start_response.json()["detail"] == (
-        "Candidate test not found for this test link"
+        "Candidate test not found or invalid UUID"
     )
 
 

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -24,6 +24,7 @@ from app.models.form import Form, FormField, FormFieldType, FormResponse
 from app.models.location import Country, District, State
 from app.models.organization_settings import (
     OrganizationSettings,
+    OrganizationSettingsPayload,
     default_organization_settings,
 )
 from app.models.question import QuestionTag, QuestionType
@@ -16220,6 +16221,181 @@ def test_external_start_rejects_candidate_test_for_other_test(
     assert start_response.json()["detail"] == (
         "Candidate test not found or invalid UUID"
     )
+
+
+def test_start_test_resume_requires_external_login_enabled(
+    client: TestClient, db: SessionDep
+) -> None:
+    """candidate_uuid resume is rejected when the org has external login disabled."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    candidate = Candidate(identity=uuid.uuid4(), organization_id=org.id)
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+    create_test_candidate_test(
+        db, admin_id=user.id, test_id=test.id, candidate_id=candidate.id
+    )
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": str(candidate.identity)},
+        json={"test_link_uuid": test_link.uuid, "device_info": "Mobile"},
+    )
+
+    assert response.status_code == 403
+    assert (
+        response.json()["detail"]
+        == "External login is not enabled for this organization"
+    )
+
+
+def test_start_test_resume_unknown_candidate_uuid(
+    client: TestClient, db: SessionDep
+) -> None:
+    """A candidate_uuid that was never provisioned resumes to a 404."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": str(uuid.uuid4())},
+        json={"test_link_uuid": test_link.uuid, "device_info": "Mobile"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Candidate test not found or invalid UUID"
+
+
+def test_start_test_anonymous_allowed_when_anonymous_starts_not_blocked(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Anonymous starts (no candidate_uuid) still work when external login is
+    enabled but block_anonymous_starts is off."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    settings_row = db.exec(
+        select(OrganizationSettings).where(
+            OrganizationSettings.organization_id == org.id
+        )
+    ).first()
+    assert settings_row is not None
+    payload = OrganizationSettingsPayload.model_validate(settings_row.settings)
+    payload.external_login.value.block_anonymous_starts = False
+    settings_row.settings = payload.model_dump(mode="json")
+    db.add(settings_row)
+    db.commit()
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    response = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        json={"test_link_uuid": test_link.uuid, "device_info": "Browser"},
+    )
+
+    assert response.status_code == 200
+    candidate_test = db.get(CandidateTest, response.json()["candidate_test_id"])
+    assert candidate_test is not None
+    candidate = db.get(Candidate, candidate_test.candidate_id)
+    assert candidate is not None
+    assert candidate.external_user_id is None
+
+
+def test_start_test_resume_respects_start_window(
+    client: TestClient, db: SessionDep
+) -> None:
+    """Resuming via candidate_uuid still enforces the test's start_time window."""
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+    enable_avanti_external_login(db, organization_id=org.id)
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+        start_time=datetime(2025, 7, 6, 12, 30, 0),
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    candidate = Candidate(
+        identity=uuid.uuid4(), organization_id=org.id, external_user_id="375220"
+    )
+    db.add(candidate)
+    db.commit()
+    db.refresh(candidate)
+    create_test_candidate_test(
+        db, admin_id=user.id, test_id=test.id, candidate_id=candidate.id
+    )
+
+    fake_now = datetime(2025, 7, 5, 12, 0, 0)
+    with patch("app.api.routes.candidate.get_current_time", return_value=fake_now):
+        response = client.post(
+            f"{settings.API_V1_STR}/candidate/start_test",
+            params={"candidate_uuid": str(candidate.identity)},
+            json={"test_link_uuid": test_link.uuid, "device_info": "Mobile"},
+        )
+
+    assert response.status_code == 400
+    assert "Test has not started yet" in response.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -98,7 +98,7 @@ def create_single_choice_question_revision(
     return revision
 
 
-def enable_avanti_external_login(
+def enable_external_org_login(
     db: SessionDep, *, organization_id: int
 ) -> OrganizationSettings:
     payload = default_organization_settings()
@@ -15742,7 +15742,7 @@ def test_start_test_rejects_anonymous_for_external_login_org(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -15805,7 +15805,7 @@ def test_external_provision_requires_sashakt_auth(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -15895,7 +15895,7 @@ def test_external_provision_and_start_resume_same_attempt(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -15950,7 +15950,7 @@ def test_external_start_reports_submitted_attempt(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16009,7 +16009,7 @@ def test_external_provision_reuses_same_candidate_across_tests(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16082,7 +16082,7 @@ def test_external_provision_is_idempotent_for_same_user_and_test(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16129,7 +16129,7 @@ def test_external_provision_distinct_users_get_distinct_candidates(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16169,7 +16169,7 @@ def test_external_start_rejects_candidate_test_for_other_test(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16276,7 +16276,7 @@ def test_start_test_resume_unknown_candidate_uuid(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None
@@ -16311,7 +16311,7 @@ def test_start_test_anonymous_allowed_when_anonymous_starts_not_blocked(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     settings_row = db.exec(
         select(OrganizationSettings).where(
@@ -16360,7 +16360,7 @@ def test_start_test_resume_respects_start_window(
     db.commit()
     db.refresh(org)
     assert org.id is not None
-    enable_avanti_external_login(db, organization_id=org.id)
+    enable_external_org_login(db, organization_id=org.id)
 
     user = create_random_user(db, organization_id=org.id)
     assert user.id is not None


### PR DESCRIPTION
## Summary

This PR build upon existing PR of provisioning external login. We can update start_test to allow candidate_UUID

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Candidates can now resume previously provisioned tests through the standard test-start flow.
  - Resuming supports candidate identifiers and reports whether the test has already been submitted.

- **Bug Fixes**
  - Resume attempts now verify external login permissions, candidate validity, and the configured test start window.
  - Anonymous test starts continue to work when permitted by organization settings.

- **Tests**
  - Added coverage for permission checks, unknown candidates, anonymous starts, and start-time restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->