### PR TITLE
Refactor role management to associate roles with organizations

### DIFF
--- a/backend/app/alembic/versions/303084e65c1e_add_permissions_for_entity.py
+++ b/backend/app/alembic/versions/303084e65c1e_add_permissions_for_entity.py
@@ -75,13 +75,15 @@ def upgrade():
         # Assign permission to specified roles
         for role_name in perm_data["roles"]:
             # Get role
-            role = session.exec(select(Role).where(Role.name == role_name)).first()
+            role_id = session.exec(
+                select(Role.id).where(Role.name == role_name)
+            ).first()
 
-            if role:
+            if role_id:
                 # Check if role_permission already exists
                 existing_role_perm = session.exec(
                     select(RolePermission).where(
-                        RolePermission.role_id == role.id,
+                        RolePermission.role_id == role_id,
                         RolePermission.permission_id == permission_id,
                     )
                 ).first()
@@ -89,7 +91,7 @@ def upgrade():
                 if not existing_role_perm:
                     # Create role_permission
                     role_permission = RolePermission(
-                        role_id=role.id, permission_id=permission_id
+                        role_id=role_id, permission_id=permission_id
                     )
                     session.add(role_permission)
                     session.commit()

--- a/backend/app/alembic/versions/587b1aa5408a_grant_update_permission_and_update_role_.py
+++ b/backend/app/alembic/versions/587b1aa5408a_grant_update_permission_and_update_role_.py
@@ -1,0 +1,76 @@
+"""grant update_permission and update_role to system_admin
+
+Revision ID: 587b1aa5408a
+Revises: ab4e987f08f7
+Create Date: 2026-07-27 18:57:14.060327
+
+"""
+from alembic import op
+from app.models.permission import Permission
+from app.models.role import Role, RolePermission
+from sqlmodel import Session, select
+
+
+# revision identifiers, used by Alembic.
+revision = '587b1aa5408a'
+down_revision = 'ab4e987f08f7'
+branch_labels = None
+depends_on = None
+
+
+
+PERMISSION_NAMES = ("update_role","read_permission")
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    permission_ids = session.exec(
+        select(Permission.id).where(Permission.name.in_(PERMISSION_NAMES))
+    ).all()
+
+    system_admin_role_ids = session.exec(
+        select(Role.id).where(Role.name == "system_admin")
+    ).all()
+
+    for role_id in system_admin_role_ids:
+        for permission_id in permission_ids:
+            existing = session.exec(
+                select(RolePermission).where(
+                    RolePermission.role_id == role_id,
+                    RolePermission.permission_id == permission_id,
+                )
+            ).first()
+            if not existing:
+                session.add(
+                    RolePermission(role_id=role_id, permission_id=permission_id)
+                )
+
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    permission_ids = session.exec(
+        select(Permission.id).where(Permission.name.in_(PERMISSION_NAMES))
+    ).all()
+
+    system_admin_role_ids = session.exec(
+        select(Role.id).where(Role.name == "system_admin")
+    ).all()
+
+    for role_id in system_admin_role_ids:
+        for permission_id in permission_ids:
+            role_permission = session.exec(
+                select(RolePermission).where(
+                    RolePermission.role_id == role_id,
+                    RolePermission.permission_id == permission_id,
+                )
+            ).first()
+            if role_permission:
+                session.delete(role_permission)
+
+    session.commit()

--- a/backend/app/alembic/versions/ab4e987f08f7_make_role_organization_id_not_null.py
+++ b/backend/app/alembic/versions/ab4e987f08f7_make_role_organization_id_not_null.py
@@ -1,0 +1,36 @@
+"""make role organization_id not null
+
+Revision ID: ab4e987f08f7
+Revises: dff7619e3cfb
+Create Date: 2026-07-27 12:54:04.041739
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ab4e987f08f7'
+down_revision = 'dff7619e3cfb'
+branch_labels = None
+depends_on = None
+
+
+# Contract step of an expand -> backfill -> contract migration. By this point
+# every role row has been backfilled with an organization_id (see revision
+# dff7619e3cfb), so it's now safe to enforce NOT NULL and uniqueness.
+UQ_NAME = "uq_role_organization_id_name"
+
+
+def upgrade():
+    op.alter_column(
+        "role", "organization_id", existing_type=sa.INTEGER(), nullable=False
+    )
+    op.create_unique_constraint(UQ_NAME, "role", ["organization_id", "name"])
+
+
+def downgrade():
+    op.drop_constraint(UQ_NAME, "role", type_="unique")
+    op.alter_column(
+        "role", "organization_id", existing_type=sa.INTEGER(), nullable=True
+    )

--- a/backend/app/alembic/versions/de518b7356af_add_bigquery_provider_tables_and_.py
+++ b/backend/app/alembic/versions/de518b7356af_add_bigquery_provider_tables_and_.py
@@ -118,14 +118,15 @@ def upgrade():
 
         # Assign permission to specified roles
         for role_name in perm_data["roles"]:
-            # Get role
-            role = session.exec(select(Role).where(Role.name == role_name)).first()
+            role_id = session.exec(
+                select(Role.id).where(Role.name == role_name)
+            ).first()
 
-            if role:
+            if role_id:
                 # Check if role_permission already exists
                 existing_role_perm = session.exec(
                     select(RolePermission).where(
-                        RolePermission.role_id == role.id,
+                        RolePermission.role_id == role_id,
                         RolePermission.permission_id == permission_id,
                     )
                 ).first()
@@ -133,7 +134,7 @@ def upgrade():
                 if not existing_role_perm:
                     # Create role_permission
                     role_permission = RolePermission(
-                        role_id=role.id, permission_id=permission_id
+                        role_id=role_id, permission_id=permission_id
                     )
                     session.add(role_permission)
                     session.commit()

--- a/backend/app/alembic/versions/dff7619e3cfb_add_organization_id_to_role_and_.py
+++ b/backend/app/alembic/versions/dff7619e3cfb_add_organization_id_to_role_and_.py
@@ -16,7 +16,7 @@ from sqlmodel import Session, select
 
 # revision identifiers, used by Alembic.
 revision = 'dff7619e3cfb'
-down_revision = 'a1e4c7b2f9d0'
+down_revision = '929353af67bf'
 branch_labels = None
 depends_on = None
 

--- a/backend/app/alembic/versions/dff7619e3cfb_add_organization_id_to_role_and_.py
+++ b/backend/app/alembic/versions/dff7619e3cfb_add_organization_id_to_role_and_.py
@@ -1,7 +1,7 @@
 """add organization_id to role and backfill existing data
 
 Revision ID: dff7619e3cfb
-Revises: a1e4c7b2f9d0
+Revises: 929353af67bf
 Create Date: 2026-07-27 12:36:10.022699
 
 """

--- a/backend/app/alembic/versions/dff7619e3cfb_add_organization_id_to_role_and_.py
+++ b/backend/app/alembic/versions/dff7619e3cfb_add_organization_id_to_role_and_.py
@@ -1,0 +1,247 @@
+"""add organization_id to role and backfill existing data
+
+Revision ID: dff7619e3cfb
+Revises: a1e4c7b2f9d0
+Create Date: 2026-07-27 12:36:10.022699
+
+"""
+from alembic import op
+from app.core.config import settings
+from app.models.organization import Organization
+from app.models.role import Role, RolePermission
+from app.models.user import User
+import sqlalchemy as sa
+from sqlmodel import Session, select
+
+
+# revision identifiers, used by Alembic.
+revision = 'dff7619e3cfb'
+down_revision = 'a1e4c7b2f9d0'
+branch_labels = None
+depends_on = None
+
+
+# Expand step of an expand -> backfill -> contract migration. `organization_id`
+# is added nullable here so existing rows can be backfilled; a follow-up
+# revision makes it NOT NULL and adds the (organization_id, name) uniqueness
+# rule once every row has a value.
+FK_NAME = "fk_role_organization_id_organization"
+
+ORG_SCOPED_ROLE_NAMES = ("system_admin", "state_admin", "test_admin", "candidate")
+
+
+def upgrade():
+    op.add_column("role", sa.Column("organization_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        FK_NAME,
+        "role",
+        "organization",
+        ["organization_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    _backfill(session)
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    _revert_backfill(session)
+    session.commit()
+
+    op.drop_constraint(FK_NAME, "role", type_="foreignkey")
+    op.drop_column("role", "organization_id")
+
+
+def _backfill(session: Session) -> None:
+    """
+    Move every role from "one shared row for the whole system" to "one row
+    per organization". Runs once against a database that predates per-org
+    roles; a no-op on a fresh install where no roles exist yet.
+    """
+    # super_admin is never cloned — there is exactly one row, ever, and it
+    # simply gets pointed at the T4D organization directly.
+    super_admin_role = session.exec(
+        select(Role).where(Role.name == "super_admin", Role.organization_id.is_(None))
+    ).first()
+    if super_admin_role is not None:
+        t4d_user = session.exec(
+            select(User).where(User.email == settings.FIRST_SUPERUSER)
+        ).first()
+        if t4d_user is None:
+            raise RuntimeError(
+                "Cannot backfill role.organization_id: no user found for "
+                f"settings.FIRST_SUPERUSER ({settings.FIRST_SUPERUSER!r}). "
+                "The T4D organization cannot be resolved."
+            )
+        super_admin_role.organization_id = t4d_user.organization_id
+        session.add(super_admin_role)
+        session.flush()
+
+
+    organizations = session.exec(select(Organization)).all()
+
+    for role_name in ORG_SCOPED_ROLE_NAMES:
+        old_role = session.exec(
+            select(Role).where(
+                Role.name == role_name, Role.organization_id.is_(None)
+            )
+        ).first()
+        if old_role is None:
+            continue
+
+        old_role_permissions = session.exec(
+            select(RolePermission).where(RolePermission.role_id == old_role.id)
+        ).all()
+
+        new_role_id_by_org_id: dict[int, int] = {}
+        for org in organizations:
+            new_role = Role(
+                name=old_role.name,
+                label=old_role.label,
+                description=old_role.description,
+                is_active=old_role.is_active,
+                organization_id=org.id,
+            )
+            session.add(new_role)
+            session.flush()
+            for role_permission in old_role_permissions:
+                session.add(
+                    RolePermission(
+                        role_id=new_role.id,
+                        permission_id=role_permission.permission_id,
+                    )
+                )
+            new_role_id_by_org_id[org.id] = new_role.id
+        session.flush()
+
+        affected_users = session.exec(
+            select(User).where(User.role_id == old_role.id)
+        ).all()
+        for user in affected_users:
+            new_role_id = new_role_id_by_org_id.get(user.organization_id)
+            if new_role_id is not None:
+                user.role_id = new_role_id
+                session.add(user)
+        session.flush()
+
+        session.delete(old_role)
+        session.flush()
+
+    _backfill_remaining_custom_roles(session)
+
+
+def _backfill_remaining_custom_roles(session: Session) -> None:
+    """
+    Handle any role that existed before this migration but isn't one of the
+    five well-known names (super_admin + the four customizable roles) — e.g.
+    a custom role an admin created via `POST /roles/` back when role names
+    weren't organization-scoped.
+
+    Unlike the four customizable roles, a custom role is only cloned into the
+    organizations that actually have a user holding it — not into every
+    organization — since it was never part of the standard seed set. A role
+    with no users at all is dead weight (a role can no longer exist without
+    an organization) and is simply dropped.
+    """
+    remaining_roles = session.exec(
+        select(Role).where(Role.organization_id.is_(None))
+    ).all()
+
+    for old_role in remaining_roles:
+        affected_users = session.exec(
+            select(User).where(User.role_id == old_role.id)
+        ).all()
+        org_ids = sorted({user.organization_id for user in affected_users})
+
+        if not org_ids:
+            session.delete(old_role)
+            session.flush()
+            continue
+
+        old_role_permissions = session.exec(
+            select(RolePermission).where(RolePermission.role_id == old_role.id)
+        ).all()
+
+        new_role_id_by_org_id: dict[int, int] = {}
+        for org_id in org_ids:
+            new_role = Role(
+                name=old_role.name,
+                label=old_role.label,
+                description=old_role.description,
+                is_active=old_role.is_active,
+                organization_id=org_id,
+            )
+            session.add(new_role)
+            session.flush()
+            for role_permission in old_role_permissions:
+                session.add(
+                    RolePermission(
+                        role_id=new_role.id,
+                        permission_id=role_permission.permission_id,
+                    )
+                )
+            new_role_id_by_org_id[org_id] = new_role.id
+        session.flush()
+
+        for user in affected_users:
+            user.role_id = new_role_id_by_org_id[user.organization_id]
+            session.add(user)
+        session.flush()
+
+        session.delete(old_role)
+        session.flush()
+
+
+def _revert_backfill(session: Session) -> None:
+    """
+    Reverse `_backfill`: merge each role name's per-organization copies back
+    into a single shared row, re-pointing every user back to it.
+    """
+    for role_name in ORG_SCOPED_ROLE_NAMES:
+        org_scoped_roles = session.exec(
+            select(Role).where(Role.name == role_name)
+        ).all()
+        if not org_scoped_roles:
+            continue
+
+        canonical_role = org_scoped_roles[0]
+        canonical_permission_ids = {
+            role_permission.permission_id
+            for role_permission in session.exec(
+                select(RolePermission).where(
+                    RolePermission.role_id == canonical_role.id
+                )
+            ).all()
+        }
+
+        for role in org_scoped_roles[1:]:
+            role_permissions = session.exec(
+                select(RolePermission).where(RolePermission.role_id == role.id)
+            ).all()
+            for role_permission in role_permissions:
+                if role_permission.permission_id not in canonical_permission_ids:
+                    session.add(
+                        RolePermission(
+                            role_id=canonical_role.id,
+                            permission_id=role_permission.permission_id,
+                        )
+                    )
+                    canonical_permission_ids.add(role_permission.permission_id)
+
+            affected_users = session.exec(
+                select(User).where(User.role_id == role.id)
+            ).all()
+            for user in affected_users:
+                user.role_id = canonical_role.id
+                session.add(user)
+            session.flush()
+
+            # Deleting the role also removes its own role_permission link
+            # rows automatically (many-to-many association cleanup).
+            session.delete(role)
+        session.flush()

--- a/backend/app/alembic/versions/e618d3c00798_add_certificate_configuration.py
+++ b/backend/app/alembic/versions/e618d3c00798_add_certificate_configuration.py
@@ -88,14 +88,15 @@ def upgrade():
 
         # Assign permission to specified roles
         for role_name in perm_data["roles"]:
-            # Get role
-            role = session.exec(select(Role).where(Role.name == role_name)).first()
+            role_id = session.exec(
+                select(Role.id).where(Role.name == role_name)
+            ).first()
 
-            if role:
+            if role_id:
                 # Check if role_permission already exists
                 existing_role_perm = session.exec(
                     select(RolePermission).where(
-                        RolePermission.role_id == role.id,
+                        RolePermission.role_id == role_id,
                         RolePermission.permission_id == permission_id,
                     )
                 ).first()
@@ -103,7 +104,7 @@ def upgrade():
                 if not existing_role_perm:
                     # Create role_permission
                     role_permission = RolePermission(
-                        role_id=role.id, permission_id=permission_id
+                        role_id=role_id, permission_id=permission_id
                     )
                     session.add(role_permission)
                     session.commit()

--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -20,7 +20,7 @@ from app.core.files import (
     save_logo_file,
     validate_logo_upload,
 )
-from app.core.roles import state_admin, test_admin
+from app.core.roles import init_org_roles, state_admin, test_admin
 from app.models import (
     DEFAULT_ORGANIZATION_SETTINGS,
     AggregatedData,
@@ -227,12 +227,15 @@ async def create_organization(
 
     try:
         session.commit()
-        session.refresh(organization)
     except Exception:
         session.rollback()
         if new_logo_path:
             delete_logo_file(new_logo_path)
         raise
+
+    init_org_roles(session, organization.id)
+
+    session.refresh(organization)
 
     return transform_organizations_to_public([organization])[0]
 

--- a/backend/app/api/routes/permissions.py
+++ b/backend/app/api/routes/permissions.py
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/permissions", tags=["permissions"])
 @router.get(
     "/",
     response_model=PermissionsPublic,
-    dependencies=[Depends(permission_dependency("create_permission"))],
+    dependencies=[Depends(permission_dependency("read_permission"))],
 )
 def read_permissions(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
     """

--- a/backend/app/api/routes/roles.py
+++ b/backend/app/api/routes/roles.py
@@ -100,12 +100,14 @@ def read_role(session: SessionDep, id: int) -> Any:
     response_model=RolePublic,
     dependencies=[Depends(permission_dependency("create_role"))],
 )
-def create_role(*, session: SessionDep, role_in: RoleCreate) -> Any:
+def create_role(
+    *, session: SessionDep, role_in: RoleCreate, current_user: CurrentUser
+) -> Any:
     """
     Create new role.
     """
     role_data = role_in.model_dump(exclude={"permissions"})
-    role = Role.model_validate(role_data)
+    role = Role(**role_data, organization_id=current_user.organization_id)
     session.add(role)
     session.commit()
     if role_in.permissions:

--- a/backend/app/api/routes/roles.py
+++ b/backend/app/api/routes/roles.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlmodel import col, func, select
 
 from app.api.deps import CurrentUser, SessionDep, permission_dependency
-from app.core.roles import get_valid_roles
+from app.core.roles import get_valid_roles, super_admin
 from app.models import (
     Message,
     Role,
@@ -21,6 +21,26 @@ router = APIRouter(
 )
 
 
+def _get_own_org_role(session: SessionDep, current_user: CurrentUser, id: int) -> Role:
+    """
+    Get role by ID, scoped to the caller's own organization.
+    """
+    role = session.get(Role, id)
+    if not role or role.organization_id != current_user.organization_id:
+        raise HTTPException(status_code=404, detail="Role not found")
+    return role
+
+
+def _ensure_not_super_admin(role: Role) -> None:
+    """
+    Block modification of the super_admin role.
+    """
+    if role.name == super_admin.name:
+        raise HTTPException(
+            status_code=403, detail="The super_admin role cannot be modified"
+        )
+
+
 @router.get(
     "/",
     response_model=RolesPublic,
@@ -30,7 +50,8 @@ def read_roles(
     session: SessionDep, current_user: CurrentUser, skip: int = 0, limit: int = 150
 ) -> Any:
     """
-    Retrieve roles based on current user's role hierarchy.
+    Retrieve roles based on current user's role hierarchy, scoped to their
+    own organization.
     """
     # get available role names based on current user's role
     available_roles = get_valid_roles(current_user.role.name)
@@ -42,13 +63,19 @@ def read_roles(
     count_statement = (
         select(func.count())
         .select_from(Role)
-        .where(col(Role.name).in_(available_roles))
+        .where(
+            col(Role.name).in_(available_roles),
+            Role.organization_id == current_user.organization_id,
+        )
     )
     count = session.exec(count_statement).one()
 
     statement = (
         select(Role)
-        .where(col(Role.name).in_(available_roles))
+        .where(
+            col(Role.name).in_(available_roles),
+            Role.organization_id == current_user.organization_id,
+        )
         .offset(skip)
         .limit(limit)
     )
@@ -76,15 +103,11 @@ def read_roles(
     response_model=RolePublic,
     dependencies=[Depends(permission_dependency("read_role"))],
 )
-def read_role(session: SessionDep, id: int) -> Any:
+def read_role(session: SessionDep, current_user: CurrentUser, id: int) -> Any:
     """
-    Get role by ID.
+    Get role by ID. See `_get_own_org_role`.
     """
-    role = session.get(Role, id)
-    if not role:
-        raise HTTPException(status_code=404, detail="Role not found")
-    # if not current_user.is_superuser and (role.owner_id != current_user.id):
-    #     raise HTTPException(status_code=400, detail="Not enough permissions")
+    role = _get_own_org_role(session, current_user, id)
     stored_permission_ids = session.exec(
         select(RolePermission.permission_id).where(RolePermission.role_id == role.id)
     )
@@ -138,17 +161,15 @@ def create_role(
 def update_role(
     *,
     session: SessionDep,
+    current_user: CurrentUser,
     id: int,
     role_update: RoleUpdate,
 ) -> Any:
     """
-    Update an role.
+    Update a role.
     """
-    role = session.get(Role, id)
-    if not role:
-        raise HTTPException(status_code=404, detail="Role not found")
-    # if not current_user.is_superuser and (role.owner_id != current_user.id):
-    #     raise HTTPException(status_code=400, detail="Not enough permissions")
+    role = _get_own_org_role(session, current_user, id)
+    _ensure_not_super_admin(role)
 
     # Updating Permission
     permission_remove = [
@@ -201,15 +222,15 @@ def update_role(
 )
 def set_visibility_role(
     session: SessionDep,
+    current_user: CurrentUser,
     id: int,
     is_active: bool = Query(True, description="Set visibility of the Role"),
 ) -> RolePublic:
     """
-    Set visitibility of the Role
+    Set visibility of the Role. See `_get_own_org_role` and `_ensure_not_super_admin`.
     """
-    role = session.get(Role, id)
-    if not role:
-        raise HTTPException(status_code=404, detail="Role not found")
+    role = _get_own_org_role(session, current_user, id)
+    _ensure_not_super_admin(role)
     role.is_active = is_active
     session.add(role)
     session.commit()
@@ -228,15 +249,12 @@ def set_visibility_role(
     "/{id}",
     dependencies=[Depends(permission_dependency("delete_role"))],
 )
-def delete_role(session: SessionDep, id: int) -> Message:
+def delete_role(session: SessionDep, current_user: CurrentUser, id: int) -> Message:
     """
-    Delete an role.
+    Delete a role. See `_get_own_org_role` and `_ensure_not_super_admin`.
     """
-    role = session.get(Role, id)
-    if not role:
-        raise HTTPException(status_code=404, detail="Role not found")
-    # if not current_user.is_superuser and (role.owner_id != current_user.id):
-    #     raise HTTPException(status_code=400, detail="Not enough permissions")
+    role = _get_own_org_role(session, current_user, id)
+    _ensure_not_super_admin(role)
     session.delete(role)
     session.commit()
     return Message(message="Role deleted successfully")

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -252,11 +252,20 @@ def read_users(
 
 
 def validate_user_return_role(
-    session: SessionDep, user_in: UserCreate | UserUpdate, current_user: User
+    session: SessionDep,
+    user_in: UserCreate | UserUpdate,
+    current_user: User,
+    target_org: int,
 ) -> Role:
     role = session.get(Role, user_in.role_id)
     if not role:
         raise HTTPException(status_code=404, detail="Invalid Role")
+
+    if role.organization_id != target_org:
+        raise HTTPException(
+            status_code=400,
+            detail="Role does not belong to the user's organization",
+        )
 
     # validate role hierarchy - check if current user can assign this role
     if not can_assign_role(current_user.role.name, role.name):
@@ -333,7 +342,10 @@ def create_user(
         user_in.organization_id = current_user.organization_id
 
     role = validate_user_return_role(
-        session=session, user_in=user_in, current_user=current_user
+        session=session,
+        user_in=user_in,
+        current_user=current_user,
+        target_org=user_in.organization_id,
     )
 
     user = crud.create_user(
@@ -567,7 +579,10 @@ def update_user(
             )
 
     role = validate_user_return_role(
-        session=session, user_in=user_in, current_user=current_user
+        session=session,
+        user_in=user_in,
+        current_user=current_user,
+        target_org=db_user.organization_id,
     )
 
     if role.name == state_admin.name:

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -10,7 +10,8 @@ from app.core.permissions import (
 )
 from app.core.providers import init_providers
 from app.core.roles import (
-    init_roles,
+    init_org_roles,
+    init_super_admin_role,
     super_admin,
 )
 from app.models import (
@@ -51,9 +52,8 @@ def init_db(session: Session) -> None:
         # Creating Initial Permissions
         init_permissions(session)
 
-        # Creating Initial Roles
-        init_roles(session)
-
+        # The T4D organization must exist before any role, since every role now
+        # belongs to a concrete organization.
         initial_organization = Organization(name="T4D", description="T4D Organization")
         session.add(initial_organization)
         session.flush()
@@ -67,8 +67,19 @@ def init_db(session: Session) -> None:
         session.commit()
         session.refresh(initial_organization)
 
+        # super_admin is created exactly once, scoped to T4D, and never cloned
+        # into any other organization.
+        init_super_admin_role(session, initial_organization.id)
+
+        # T4D also gets its own copies of the four customizable roles, same as
+        # any other organization.
+        init_org_roles(session, initial_organization.id)
+
         super_admin_role = session.exec(
-            select(Role.id).where(Role.name == super_admin.name)
+            select(Role.id).where(
+                Role.name == super_admin.name,
+                Role.organization_id == initial_organization.id,
+            )
         ).first()
 
         user_in = UserCreate(

--- a/backend/app/core/permission_data.json
+++ b/backend/app/core/permission_data.json
@@ -228,7 +228,7 @@
     "name": "read_permission",
     "description": "Read Permission Details",
     "super_admin": true,
-    "system_admin": false,
+    "system_admin": true,
     "state_admin": false,
     "test_admin": false,
     "candidate": false
@@ -390,7 +390,7 @@
     "name": "update_role",
     "description": "Update Existing Role",
     "super_admin": true,
-    "system_admin": false,
+    "system_admin": true,
     "state_admin": false,
     "test_admin": false,
     "candidate": false

--- a/backend/app/core/roles.py
+++ b/backend/app/core/roles.py
@@ -65,14 +65,23 @@ def get_role_permissions(role: RoleCreate, session: Session) -> list[int]:
 
 
 def create_role(
-    session: Session, role_create: RoleCreate, permissions: list[int]
+    session: Session,
+    role_create: RoleCreate,
+    permissions: list[int],
+    organization_id: int,
 ) -> RolePublic:
     current_role = session.exec(
-        select(Role).where(Role.name == role_create.name)
+        select(Role).where(
+            Role.name == role_create.name,
+            Role.organization_id == organization_id,
+        )
     ).first()
 
     if not current_role:
-        current_role = Role(**role_create.model_dump())
+        current_role = Role(
+            **role_create.model_dump(exclude={"permissions"}),
+            organization_id=organization_id,
+        )
         session.add(current_role)
         session.commit()
         session.refresh(current_role)
@@ -99,26 +108,27 @@ def create_role(
     return RolePublic(**current_role.model_dump(), permissions=stored_permission_ids)
 
 
-def init_roles(session: Session) -> None:
+def init_super_admin_role(session: Session, organization_id: int) -> None:
     """
-    Function to initialize roles in the database.
-    It creates roles based on the data provided in permission_data.json file.
+    Create the single, global super_admin role, scoped to the T4D organization.
+
+    This must only ever be called once, for T4D — super_admin is never cloned
+    into any other organization.
     """
-    super_admin_permissions = get_role_permissions(super_admin, session)
-    system_admin_permissions = get_role_permissions(system_admin, session)
-    state_admin_permissions = get_role_permissions(state_admin, session)
-    test_admin_permissions = get_role_permissions(test_admin, session)
-    candidate_permissions = get_role_permissions(candidate, session)
+    permissions = get_role_permissions(super_admin, session)
+    create_role(session, super_admin, permissions, organization_id=organization_id)
 
-    create_role(session, super_admin, super_admin_permissions)
 
-    create_role(session, system_admin, system_admin_permissions)
+def init_org_roles(session: Session, organization_id: int) -> None:
+    """
+    Create the four customizable roles (system_admin, state_admin, test_admin,
+    candidate) with their default permissions for one organization.
 
-    create_role(session, state_admin, state_admin_permissions)
-
-    create_role(session, test_admin, test_admin_permissions)
-
-    create_role(session, candidate, candidate_permissions)
+    Safe to call for any organization, including T4D. Idempotent per organization.
+    """
+    for role in (system_admin, state_admin, test_admin, candidate):
+        permissions = get_role_permissions(role, session)
+        create_role(session, role, permissions, organization_id=organization_id)
 
 
 def get_role_hierarchy() -> dict[str, list[str]]:

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -66,7 +66,9 @@ class Organization(OrganizationBase, table=True):
         back_populates="organization",
         sa_relationship_kwargs={"uselist": False},
     )
-    roles: list["Role"] = Relationship(back_populates="organization")
+    roles: list["Role"] = Relationship(
+        back_populates="organization", cascade_delete=True
+    )
 
 
 class OrganizationCreate(OrganizationBase):

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -7,7 +7,16 @@ from app.core.timezone import get_timezone_aware_now
 from app.models.candidate import Candidate
 
 if TYPE_CHECKING:
-    from app.models import Certificate, EntityType, Question, Tag, TagType, Test, User
+    from app.models import (
+        Certificate,
+        EntityType,
+        Question,
+        Role,
+        Tag,
+        TagType,
+        Test,
+        User,
+    )
     from app.models.form import Form
     from app.models.organization_settings import OrganizationSettings
     from app.models.provider import OrganizationProvider
@@ -57,6 +66,7 @@ class Organization(OrganizationBase, table=True):
         back_populates="organization",
         sa_relationship_kwargs={"uselist": False},
     )
+    roles: list["Role"] = Relationship(back_populates="organization")
 
 
 class OrganizationCreate(OrganizationBase):

--- a/backend/app/models/role.py
+++ b/backend/app/models/role.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from sqlmodel import Field, Relationship, SQLModel, UniqueConstraint
 
 if TYPE_CHECKING:
-    from app.models import Permission, User
+    from app.models import Organization, Permission, User
 
 
 class RolePermission(SQLModel, table=True):
@@ -35,7 +35,11 @@ class RoleUpdate(RoleBase):
 # Database model, database table inferred from class name
 class Role(RoleBase, table=True):
     id: int | None = Field(default=None, primary_key=True)
+    organization_id: int = Field(foreign_key="organization.id", ondelete="CASCADE")
+    __table_args__ = (UniqueConstraint("organization_id", "name"),)
+
     users: list["User"] = Relationship(back_populates="role")
+    organization: "Organization" = Relationship(back_populates="roles")
     permissions: list["Permission"] | None = Relationship(
         back_populates="roles", link_model=RolePermission
     )
@@ -44,6 +48,7 @@ class Role(RoleBase, table=True):
 # Properties to return via API, id is always required
 class RolePublic(RoleBase):
     id: int
+    organization_id: int
     permissions: list[int]
 
 

--- a/backend/app/populate_sample_data.py
+++ b/backend/app/populate_sample_data.py
@@ -20,6 +20,7 @@ from sqlmodel import Session, select
 
 from app import crud
 from app.core.db import engine
+from app.core.roles import init_org_roles
 from app.crud import organization_settings as crud_organization_settings
 from app.models import (
     District,
@@ -82,8 +83,20 @@ def _already_seeded(session: Session) -> bool:
     return existing is not None
 
 
-def _get_role(session: Session, name: str) -> Role:
-    role = session.exec(select(Role).where(Role.name == name)).first()
+def _get_role(
+    session: Session, name: str, *, organization_id: int | None = None
+) -> Role:
+    """
+    Look up a role by name.
+
+    Pass `organization_id` for any of the four customizable roles, since each
+    organization now has its own copy of them. Leave it unset only for
+    `super_admin`, which is the single, globally unique role.
+    """
+    statement = select(Role).where(Role.name == name)
+    if organization_id is not None:
+        statement = statement.where(Role.organization_id == organization_id)
+    role = session.exec(statement).first()
     if role is None:
         raise RuntimeError(
             f"Role {name!r} not found — run `python app/initial_data.py` first."
@@ -104,6 +117,9 @@ def _get_or_create_organization(session: Session) -> Organization:
     session.add(org)
     session.commit()
     session.refresh(org)
+    if org.id is None:
+        raise RuntimeError("Failed to create Sample Organization")
+    init_org_roles(session, org.id)
     return org
 
 
@@ -498,7 +514,7 @@ def seed(session: Session) -> None:
 
     created_users: list[User] = []
     for spec in USERS:
-        role = _get_role(session, spec["role"])
+        role = _get_role(session, spec["role"], organization_id=org.id)
         assert role.id is not None
         user = _create_user(
             session,

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -28,7 +28,6 @@ from app.models.organization_settings import (
     default_organization_settings,
 )
 from app.models.question import QuestionTag, QuestionType
-from app.models.role import Role
 from app.models.tag import Tag, TagType
 from app.models.test import (
     MarksLevelEnum,
@@ -46,6 +45,7 @@ from app.tests.utils.candidate import (
 )
 from app.tests.utils.organization import create_random_organization
 from app.tests.utils.question_revisions import create_random_question_revision
+from app.tests.utils.role import get_org_role
 from app.tests.utils.test import get_test_link
 from app.tests.utils.user import (
     authentication_token_from_email,
@@ -4940,8 +4940,7 @@ def test_overall_avg_score_state_admin_location_restricted(
     user_id = user_data["id"]
     org_id = user_data["organization_id"]
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, org_id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -5117,8 +5116,7 @@ def test_overall_avg_time_state_admin_location_restricted(
     user_data = get_current_user_data(client, get_user_superadmin_token)
     user_id = user_data["id"]
     org_id = user_data["organization_id"]
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, org_id, "state_admin")
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -10913,11 +10911,10 @@ def test_candidate_active_inside_time_limit(
 def test_summary_filtered_by_state(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
     user_data = get_current_user_data(client, get_user_superadmin_token)
     user_id = user_data["id"]
     org_id = user_data["organization_id"]
+    state_admin_role = get_org_role(db, org_id, "state_admin")
 
     email = random_email()
 
@@ -11028,11 +11025,10 @@ def test_summary_filtered_by_state(
 def test_summary_filtered_by_district(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
     user_data = get_current_user_data(client, get_user_superadmin_token)
     user_id = user_data["id"]
     org_id = user_data["organization_id"]
+    state_admin_role = get_org_role(db, org_id, "state_admin")
 
     email = random_email()
 
@@ -11160,11 +11156,10 @@ def test_summary_filtered_by_district(
 def test_summary_active_submitted_by_state(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
     user_data = get_current_user_data(client, get_user_superadmin_token)
     user_id = user_data["id"]
     org_id = user_data["organization_id"]
+    state_admin_role = get_org_role(db, org_id, "state_admin")
 
     email = random_email()
 
@@ -11276,11 +11271,10 @@ def test_summary_active_submitted_by_state(
 def test_summary_active_submitted_by_district(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
     user_data = get_current_user_data(client, get_user_superadmin_token)
     user_id = user_data["id"]
     org_id = user_data["organization_id"]
+    state_admin_role = get_org_role(db, org_id, "state_admin")
 
     email = random_email()
 

--- a/backend/app/tests/api/routes/test_location.py
+++ b/backend/app/tests/api/routes/test_location.py
@@ -6,14 +6,13 @@ import tempfile
 
 from fastapi import status
 from fastapi.testclient import TestClient
-from sqlmodel import select
 
 from app.api.deps import SessionDep
 from app.core.config import settings
 from app.models.location import Block, Country, District, State
-from app.models.role import Role
 from app.models.test import Test, TestDistrict, TestState
 from app.tests.utils.organization import create_random_organization
+from app.tests.utils.role import get_org_role
 from app.tests.utils.user import authentication_token_from_email, create_random_user
 from app.tests.utils.utils import assert_paginated_response
 
@@ -1120,8 +1119,7 @@ def test_get_state_admin_state_list(
     assert response.status_code == 200
     assert len(data["items"]) > 1
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -1152,8 +1150,7 @@ def test_get_state_admin_state_list(
 
     # ---Check test for test admin
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
 
     test_admin_email = random_email()
     test_admin_payload = {
@@ -1232,8 +1229,7 @@ def test_filter_district_for_state_admin(
     assert response.status_code == 200
     assert len(data["items"]) > 1
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -1266,8 +1262,7 @@ def test_filter_district_for_state_admin(
     assert district_2.id in district_ids
     assert district_3.id not in district_ids
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
 
     test_admin_email = random_email()
     test_admin_payload = {

--- a/backend/app/tests/api/routes/test_organization.py
+++ b/backend/app/tests/api/routes/test_organization.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
-from sqlmodel import select
 
 from app.api.deps import SessionDep
 from app.core.config import settings
@@ -15,7 +14,6 @@ from app.models.question import (
     QuestionRevision,
     QuestionType,
 )
-from app.models.role import Role
 from app.models.test import Test, TestState
 from app.models.user import UserDistrict, UserState
 from app.tests.utils.files import (
@@ -26,6 +24,7 @@ from app.tests.utils.files import (
 from app.tests.utils.organization import (
     create_random_organization,
 )
+from app.tests.utils.role import get_org_role
 from app.tests.utils.user import (
     authentication_token_from_email,
     create_random_user,
@@ -878,8 +877,7 @@ def test_aggregated_data_for_state_admin(
     db.refresh(state_x)
     db.refresh(state_y)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -1021,8 +1019,7 @@ def test_aggregated_data_for_state_admin_for_district(
     db.refresh(district_x3)
     db.refresh(district_y1)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, organization_id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -1176,8 +1173,7 @@ def test_aggregated_data_for_state_admin_distinct_check(
     db.refresh(state_x)
     db.refresh(state_y)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -1348,8 +1344,7 @@ def test_get_current_organization(
     db.refresh(org)
 
     email_with_org = random_email()
-    role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "test_admin")
 
     user_payload = {
         "email": email_with_org,
@@ -1391,8 +1386,7 @@ def test_update_current_organization(
     db.commit()
     db.refresh(org)
 
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     client.post(
@@ -1479,8 +1473,7 @@ def test_update_current_organization_with_logo(
     """Test updating organization with valid logo upload."""
 
     org = create_random_organization(db)
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     password = random_lower_string()
@@ -1529,8 +1522,7 @@ def test_update_current_organization_without_logo(
     db.commit()
     db.refresh(org)
 
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     password = random_lower_string()
@@ -1568,8 +1560,7 @@ def test_update_organization_logo_invalid_file_type(
     """Test rejecting invalid file types (non-image files)."""
 
     org = create_random_organization(db)
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     password = random_lower_string()
@@ -1610,8 +1601,7 @@ def test_update_organization_logo_file_too_large(
     """Test rejecting files larger than 2MB."""
 
     org = create_random_organization(db)
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     password = random_lower_string()
@@ -1662,8 +1652,7 @@ def test_update_organization_logo_replaces_old(
     db.commit()
     db.refresh(org)
 
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     password = random_lower_string()
@@ -1709,8 +1698,7 @@ def test_delete_current_organization_logo_success(
     db.commit()
     db.refresh(org)
 
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     password = random_lower_string()
@@ -1752,8 +1740,7 @@ def test_delete_logo_when_none_exists(
     db.commit()
     db.refresh(org)
 
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     password = random_lower_string()
@@ -1788,8 +1775,7 @@ def test_update_organization_logo_empty_file(
 ) -> None:
     """Test rejecting empty file upload."""
     org = create_random_organization(db)
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     password = random_lower_string()
@@ -1830,8 +1816,7 @@ def test_update_organization_logo_no_filename(
     from app.tests.utils.files import create_test_image
 
     org = create_random_organization(db)
-    role = db.exec(select(Role).where(Role.name == "super_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "super_admin")
 
     email = random_email()
     password = random_lower_string()

--- a/backend/app/tests/api/routes/test_question.py
+++ b/backend/app/tests/api/routes/test_question.py
@@ -22,12 +22,12 @@ from app.models.question import (
     QuestionTag,
     QuestionType,
 )
-from app.models.role import Role
 from app.models.tag import Tag, TagType
 from app.models.test import Test, TestQuestion
 from app.models.user import UserState
 from app.tests.utils.organization import create_random_organization
 from app.tests.utils.question_revisions import create_random_question_revision
+from app.tests.utils.role import get_org_role
 
 # from app.models.user import User
 from app.tests.utils.user import (
@@ -5372,9 +5372,6 @@ def test_bulk_upload_questions_with_extra_column(
 def test_state_admin_cannot_delete_question_outside_location(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -5388,6 +5385,7 @@ def test_state_admin_cannot_delete_question_outside_location(
     db.refresh(state_y)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -5440,9 +5438,6 @@ def test_state_admin_cannot_delete_question_outside_location(
 def test_state_admin_cannot_delete_multi_state_question_without_full_access(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -5456,6 +5451,7 @@ def test_state_admin_cannot_delete_multi_state_question_without_full_access(
     db.refresh(state_b)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -5508,9 +5504,6 @@ def test_state_admin_cannot_delete_multi_state_question_without_full_access(
 def test_state_admin_cannot_delete_general_question(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -5522,6 +5515,7 @@ def test_state_admin_cannot_delete_general_question(
     db.refresh(state)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -5574,9 +5568,6 @@ def test_state_admin_cannot_delete_general_question(
 def test_state_admin_delete_question_same_location(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -5588,6 +5579,7 @@ def test_state_admin_delete_question_same_location(
     db.refresh(state)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -5639,9 +5631,6 @@ def test_state_admin_delete_question_same_location(
 def test_state_admin_cannot_update_general_question(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -5653,6 +5642,7 @@ def test_state_admin_cannot_update_general_question(
     db.refresh(state)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -5699,9 +5689,6 @@ def test_state_admin_cannot_update_general_question(
 def test_state_admin_can_update_question_in_their_state(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -5713,6 +5700,7 @@ def test_state_admin_can_update_question_in_their_state(
     db.refresh(state)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -5759,9 +5747,6 @@ def test_state_admin_can_update_question_in_their_state(
 def test_state_admin_cannot_update_question_outside_their_state(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -5779,6 +5764,7 @@ def test_state_admin_cannot_update_question_outside_their_state(
     db.refresh(other_state)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -5825,8 +5811,6 @@ def test_state_admin_cannot_update_question_outside_their_state(
 def test_state_admin_cannot_update_tags_for_general_question(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
     org = Organization(name=random_lower_string())
     db.add(org)
     user = create_random_user(db)
@@ -5863,6 +5847,7 @@ def test_state_admin_cannot_update_tags_for_general_question(
     db.refresh(other_state)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -5927,8 +5912,7 @@ def test_question_list_state_user(
     db.refresh(state_x)
     db.refresh(state_y)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -6081,8 +6065,7 @@ def test_question_list_state_user(
     assert data["total"] == 8
     assert len(data["items"]) == 8
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -6187,9 +6170,6 @@ def test_update_question_locations_not_found(
 def test_bulk_delete_state_admin_cannot_delete_questions_outside_location(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -6203,6 +6183,7 @@ def test_bulk_delete_state_admin_cannot_delete_questions_outside_location(
     db.refresh(state_y)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -6346,9 +6327,6 @@ def test_create_question_revision_not_found(
 def test_bulk_delete_state_admin_cannot_delete_general_questions(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -6360,6 +6338,7 @@ def test_bulk_delete_state_admin_cannot_delete_general_questions(
     db.refresh(state)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -6438,9 +6417,6 @@ def test_bulk_delete_state_admin_cannot_delete_general_questions(
 def test_bulk_delete_state_admin_delete_questions_same_location(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -6452,6 +6428,7 @@ def test_bulk_delete_state_admin_delete_questions_same_location(
     db.refresh(state)
 
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {

--- a/backend/app/tests/api/routes/test_role.py
+++ b/backend/app/tests/api/routes/test_role.py
@@ -586,7 +586,14 @@ def test_role_actions_scoped_to_callers_own_org(
 def test_super_admin_role_is_protected_from_modification(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    super_admin_role = db.exec(select(Role).where(Role.name == "super_admin")).first()
+    caller_org_id = get_current_user_data(client, superuser_token_headers)[
+        "organization_id"
+    ]
+    super_admin_role = db.exec(
+        select(Role).where(
+            Role.name == "super_admin", Role.organization_id == caller_org_id
+        )
+    ).first()
     assert super_admin_role is not None
 
     update_response = client.put(

--- a/backend/app/tests/api/routes/test_role.py
+++ b/backend/app/tests/api/routes/test_role.py
@@ -4,7 +4,7 @@ from sqlmodel import Session, select
 from app.core.config import settings
 from app.models import Permission, Role, RolePermission
 from app.tests.utils.role import create_random_role
-from app.tests.utils.user import get_user_token
+from app.tests.utils.user import get_current_user_data, get_user_token
 from app.tests.utils.utils import random_lower_string
 
 
@@ -77,7 +77,10 @@ def test_read_role(
 
     db.commit()
 
-    role = create_random_role(db)
+    caller_org_id = get_current_user_data(client, superuser_token_headers)[
+        "organization_id"
+    ]
+    role = create_random_role(db, organization_id=caller_org_id)
 
     role_permission_a = RolePermission(role_id=role.id, permission_id=permission_a.id)
     role_permission_b = RolePermission(role_id=role.id, permission_id=permission_b.id)
@@ -176,7 +179,10 @@ def test_read_roles(
 def test_update_role(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    role = create_random_role(db)
+    caller_org_id = get_current_user_data(client, superuser_token_headers)[
+        "organization_id"
+    ]
+    role = create_random_role(db, organization_id=caller_org_id)
     permission_a = Permission(
         name=random_lower_string(), description=random_lower_string()
     )
@@ -278,7 +284,10 @@ def test_update_role_not_found(
 def test_visibility_role(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    role = create_random_role(db)
+    caller_org_id = get_current_user_data(client, superuser_token_headers)[
+        "organization_id"
+    ]
+    role = create_random_role(db, organization_id=caller_org_id)
     data = {"is_active": False}
     response = client.patch(
         f"{settings.API_V1_STR}/roles/{role.id}",
@@ -329,7 +338,10 @@ def test_visibility_role(
 def test_delete_role(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    role = create_random_role(db)
+    caller_org_id = get_current_user_data(client, superuser_token_headers)[
+        "organization_id"
+    ]
+    role = create_random_role(db, organization_id=caller_org_id)
     response = client.delete(
         f"{settings.API_V1_STR}/roles/{role.id}",
         headers=superuser_token_headers,
@@ -373,15 +385,13 @@ def test_delete_role_not_found(
 #     assert content["detail"] == "Not enough permissions"
 
 
-def test_read_roles_super_admin_sees_all_roles(client: TestClient, db: Session) -> None:
+def test_read_roles_super_admin_sees_all_roles(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
     """Test that Super Admin can see all system roles."""
-
-    # get auth headers for super admin user
-    headers = get_user_token(db=db, role="super_admin")
-
     response = client.get(
         f"{settings.API_V1_STR}/roles/",
-        headers=headers,
+        headers=superuser_token_headers,
     )
     assert response.status_code == 200
     content = response.json()
@@ -510,3 +520,149 @@ def test_read_roles_invalid_role_empty_result(client: TestClient, db: Session) -
         # Custom role not in hierarchy should see no roles
         assert content["count"] == 0
         assert len(content["data"]) == 0
+
+
+def test_create_role_stamps_callers_own_org(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    """POST /roles/ always attaches the caller's own organization, never
+    something the client could smuggle in."""
+    caller_org_id = get_current_user_data(client, superuser_token_headers)[
+        "organization_id"
+    ]
+    data = {
+        "name": random_lower_string(),
+        "description": random_lower_string(),
+        "label": random_lower_string(),
+    }
+    response = client.post(
+        f"{settings.API_V1_STR}/roles/",
+        headers=superuser_token_headers,
+        json=data,
+    )
+    assert response.status_code == 200
+    assert response.json()["organization_id"] == caller_org_id
+
+
+def test_role_actions_scoped_to_callers_own_org(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    """A caller (even one with role-management permission) cannot see, edit,
+    hide, or delete a role that belongs to a different organization."""
+    other_org_headers = get_user_token(db=db, role="test_admin")
+    other_org_role_id = get_current_user_data(client, other_org_headers)["role_id"]
+
+    read_response = client.get(
+        f"{settings.API_V1_STR}/roles/{other_org_role_id}",
+        headers=superuser_token_headers,
+    )
+    assert read_response.status_code == 404
+
+    update_response = client.put(
+        f"{settings.API_V1_STR}/roles/{other_org_role_id}",
+        headers=superuser_token_headers,
+        json={
+            "name": random_lower_string(),
+            "description": random_lower_string(),
+            "label": random_lower_string(),
+        },
+    )
+    assert update_response.status_code == 404
+
+    patch_response = client.patch(
+        f"{settings.API_V1_STR}/roles/{other_org_role_id}",
+        headers=superuser_token_headers,
+        params={"is_active": False},
+    )
+    assert patch_response.status_code == 404
+
+    delete_response = client.delete(
+        f"{settings.API_V1_STR}/roles/{other_org_role_id}",
+        headers=superuser_token_headers,
+    )
+    assert delete_response.status_code == 404
+
+
+def test_super_admin_role_is_protected_from_modification(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    super_admin_role = db.exec(select(Role).where(Role.name == "super_admin")).first()
+    assert super_admin_role is not None
+
+    update_response = client.put(
+        f"{settings.API_V1_STR}/roles/{super_admin_role.id}",
+        headers=superuser_token_headers,
+        json={
+            "name": random_lower_string(),
+            "description": random_lower_string(),
+            "label": random_lower_string(),
+        },
+    )
+    assert update_response.status_code == 403
+
+    patch_response = client.patch(
+        f"{settings.API_V1_STR}/roles/{super_admin_role.id}",
+        headers=superuser_token_headers,
+        params={"is_active": False},
+    )
+    assert patch_response.status_code == 403
+
+    delete_response = client.delete(
+        f"{settings.API_V1_STR}/roles/{super_admin_role.id}",
+        headers=superuser_token_headers,
+    )
+    assert delete_response.status_code == 403
+
+
+def test_toggle_permission_scoped_to_one_org(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    """The worked example from the issue: removing read_test from one org's
+    test_admin must not affect another org's test_admin."""
+    read_test_permission = db.exec(
+        select(Permission).where(Permission.name == "read_test")
+    ).first()
+    assert read_test_permission is not None
+
+    caller_org_id = get_current_user_data(client, superuser_token_headers)[
+        "organization_id"
+    ]
+    org_a_test_admin = db.exec(
+        select(Role).where(
+            Role.name == "test_admin", Role.organization_id == caller_org_id
+        )
+    ).first()
+    assert org_a_test_admin is not None
+
+    other_org_headers = get_user_token(db=db, role="test_admin")
+    other_org_user = get_current_user_data(client, other_org_headers)
+    org_b_test_admin_id = other_org_user["role_id"]
+
+    other_permission_ids = list(
+        db.exec(
+            select(RolePermission.permission_id).where(
+                RolePermission.role_id == org_a_test_admin.id,
+                RolePermission.permission_id != read_test_permission.id,
+            )
+        ).all()
+    )
+
+    response = client.put(
+        f"{settings.API_V1_STR}/roles/{org_a_test_admin.id}",
+        headers=superuser_token_headers,
+        json={
+            "name": org_a_test_admin.name,
+            "description": org_a_test_admin.description,
+            "label": org_a_test_admin.label,
+            "permissions": other_permission_ids,
+        },
+    )
+    assert response.status_code == 200
+    assert read_test_permission.id not in response.json()["permissions"]
+
+    org_b_permission_ids = db.exec(
+        select(RolePermission.permission_id).where(
+            RolePermission.role_id == org_b_test_admin_id
+        )
+    ).all()
+    assert read_test_permission.id in org_b_permission_ids

--- a/backend/app/tests/api/routes/test_test.py
+++ b/backend/app/tests/api/routes/test_test.py
@@ -29,7 +29,6 @@ from app.models.candidate import Candidate, CandidateTest, CandidateTestAnswer
 from app.models.certificate import Certificate
 from app.models.location import District
 from app.models.question import QuestionType
-from app.models.role import Role
 from app.models.test import OMRMode, QuestionSet, TestDistrict
 from app.models.user import UserState
 from app.tests.utils.location import create_random_state
@@ -38,6 +37,7 @@ from app.tests.utils.organization import (
 )
 from app.tests.utils.organization_settings import make_current_user_org_flexible
 from app.tests.utils.question_revisions import create_random_question_revision
+from app.tests.utils.role import get_org_role
 from app.tests.utils.tag import create_random_tag
 from app.tests.utils.test import get_test_link
 from app.tests.utils.user import (
@@ -4524,9 +4524,7 @@ def test_bulk_delete_state_admin_cannot_delete_general_tests(
 ) -> None:
     user_data = get_current_user_data(client, get_user_superadmin_token)
     org_id = user_data["organization_id"]
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
+    state_admin_role = get_org_role(db, org_id, "state_admin")
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -4611,8 +4609,7 @@ def test_bulk_delete_state_admin_cannot_delete_tests_outside_location(
 ) -> None:
     user_data = get_current_user_data(client, get_user_superadmin_token)
     org_id = user_data["organization_id"]
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
+    state_admin_role = get_org_role(db, org_id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -4700,8 +4697,7 @@ def test_bulk_delete_state_admin_delete_tests_same_location(
 ) -> None:
     user_data = get_current_user_data(client, get_user_superadmin_token)
     org_id = user_data["organization_id"]
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
+    state_admin_role = get_org_role(db, org_id, "state_admin")
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -5734,9 +5730,8 @@ def test_update_test_not_created_by_user(
     db: SessionDep,
     get_user_systemadmin_token: dict[str, str],
 ) -> None:
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role
     org = get_current_user_data(client, get_user_systemadmin_token)["organization_id"]
+    test_admin_role = get_org_role(db, org, "test_admin")
 
     email_a = random_email()
     client.post(
@@ -5791,10 +5786,8 @@ def test_update_test_same_role_different_user_forbidden(
     db: SessionDep,
     get_user_systemadmin_token: dict[str, str],
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     org = get_current_user_data(client, get_user_systemadmin_token)["organization_id"]
+    state_admin_role = get_org_role(db, org, "state_admin")
 
     country = Country(name=random_lower_string())
     db.add(country)
@@ -7504,8 +7497,7 @@ def test_test_list_state_user(
     db.refresh(state_x)
     db.refresh(state_y)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -7624,8 +7616,7 @@ def test_state_admin_can_see_test_created_by_another_state_admin_same_state(
     db.commit()
     db.refresh(state_x)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email_a = random_email()
     response_a = client.post(
@@ -7701,8 +7692,7 @@ def test_state_admin_cannot_see_general_test_no_location(
     db.commit()
     db.refresh(state_x)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     client.post(
@@ -7775,8 +7765,7 @@ def test_state_admin_cannot_see_district_only_test(
     db.commit()
     db.refresh(district_x)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -7855,8 +7844,7 @@ def test_state_admin_cannot_see_state_and_district_test(
     db.commit()
     db.refresh(district_x)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -7915,10 +7903,8 @@ def test_state_admin_cannot_see_state_and_district_test(
 def test_state_admin_can_delete_test_created_by_them(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -7983,10 +7969,8 @@ def test_state_admin_can_delete_test_created_by_them(
 def test_state_admin_can_delete_test_in_their_state(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -8051,10 +8035,8 @@ def test_state_admin_can_delete_test_in_their_state(
 def test_state_admin_cannot_delete_test_outside_their_state(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -8112,10 +8094,8 @@ def test_state_admin_cannot_delete_test_outside_their_state(
 def test_state_admin_cannot_delete_multi_state_test_without_full_access(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -8173,10 +8153,8 @@ def test_state_admin_cannot_delete_multi_state_test_without_full_access(
 def test_state_admin_can_delete_test_connected_via_district(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
     country = Country(name=random_lower_string())
     db.add(country)
     db.commit()
@@ -8248,10 +8226,8 @@ def test_state_admin_can_delete_test_connected_via_district(
 def test_state_admin_cannot_delete_multi_district_test_unless_self_created(
     client: TestClient, db: SessionDep, get_user_superadmin_token: dict[str, str]
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     country = Country(name=random_lower_string())
     db.add(country)
@@ -8636,10 +8612,8 @@ def test_district_user_cannot_modify_out_of_scope_test(
     db: SessionDep,
     get_user_systemadmin_token: dict[str, str],
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     org = get_current_user_data(client, get_user_systemadmin_token)["organization_id"]
+    state_admin_role = get_org_role(db, org, "state_admin")
 
     country = Country(name=random_lower_string())
     db.add(country)
@@ -8789,8 +8763,7 @@ def test_get_tests_by_district_user(
 
     email = random_email()
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
+    state_admin_role = get_org_role(db, org_id, "state_admin")
     state_admin_user_payload = {
         "email": email,
         "password": random_lower_string(),
@@ -8938,8 +8911,7 @@ def test_test_admin_with_district_can_see_state_level_test(
     db.refresh(rohtak)
 
     # Create state_admin scoped to Haryana
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
     state_admin_email = random_email()
     client.post(
         f"{settings.API_V1_STR}/users/",
@@ -8959,8 +8931,7 @@ def test_test_admin_with_district_can_see_state_level_test(
     )
 
     # Create test_admin scoped to Ambala district
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
     test_admin_email = random_email()
     client.post(
         f"{settings.API_V1_STR}/users/",
@@ -9047,8 +9018,7 @@ def test_state_admin_cannot_see_district_level_test(
     db.refresh(ambala)
 
     # Create state_admin scoped to Haryana
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
     state_admin_email = random_email()
     client.post(
         f"{settings.API_V1_STR}/users/",
@@ -9068,8 +9038,7 @@ def test_state_admin_cannot_see_district_level_test(
     )
 
     # Create test_admin scoped to Ambala district
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
     test_admin_email = random_email()
     client.post(
         f"{settings.API_V1_STR}/users/",
@@ -9157,8 +9126,7 @@ def test_district_user_can_see_test_created_by_peer_in_same_district(
     db.refresh(district_a)
     db.refresh(district_b)
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
 
     # First test_admin — scoped to district_a (creator)
     creator_email = random_email()
@@ -9286,8 +9254,7 @@ def test_district_user_cannot_see_general_test_no_location(
     db.commit()
     db.refresh(district)
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
 
     district_user_email = random_email()
     client.post(
@@ -9370,10 +9337,8 @@ def test_district_user_cannot_see_test_from_state_admin_of_different_state(
     db.commit()
     db.refresh(district_x)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
 
     # state_admin scoped to state X
     state_admin_x_email = random_email()
@@ -9496,8 +9461,7 @@ def test_unscoped_test_admin_can_see_all_org_tests(
     db.commit()
     db.refresh(state)
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
 
     # test_admin with no district or state assigned
     unscoped_email = random_email()
@@ -10236,9 +10200,6 @@ def test_get_tests_my_tests_filter(
 ) -> None:
     """my_tests=True returns only tests created by the current user;
     my_tests=False excludes them — regardless of location assignment."""
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
-
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
     db.commit()
@@ -10250,6 +10211,7 @@ def test_get_tests_my_tests_filter(
     db.add(org_district)
     db.commit()
     db.refresh(org_district)
+    test_admin_role = get_org_role(db, org_district.id, "test_admin")
 
     state_d = State(name=random_lower_string(), is_active=True, country_id=country.id)
     db.add(state_d)
@@ -10356,6 +10318,7 @@ def test_get_tests_my_tests_filter(
     db.add(org_state)
     db.commit()
     db.refresh(org_state)
+    state_test_admin_role = get_org_role(db, org_state.id, "test_admin")
 
     state_s = State(name=random_lower_string(), is_active=True, country_id=country.id)
     db.add(state_s)
@@ -10370,7 +10333,7 @@ def test_get_tests_my_tests_filter(
             "password": random_lower_string(),
             "phone": random_lower_string(),
             "full_name": random_lower_string(),
-            "role_id": test_admin_role.id,
+            "role_id": state_test_admin_role.id,
             "organization_id": org_state.id,
             "state_ids": [state_s.id],
         },
@@ -10538,8 +10501,7 @@ def test_state_admin_can_see_tests_they_created_outside_their_location(
     db.refresh(state_a)
     db.refresh(state_b)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
     state_admin_email = random_email()
     client.post(
         f"{settings.API_V1_STR}/users/",
@@ -10643,8 +10605,7 @@ def test_test_admin_can_see_tests_they_created_outside_their_district(
     db.refresh(district_a)
     db.refresh(district_b)
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert test_admin_role is not None
+    test_admin_role = get_org_role(db, new_organization.id, "test_admin")
     test_admin_email = random_email()
     client.post(
         f"{settings.API_V1_STR}/users/",

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -174,6 +174,33 @@ def test_create_user_new_email_without_org_id(
         assert user.created_by_id == current_user_data["id"]
 
 
+def test_create_user_role_from_different_organization(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    """A role must belong to the same organization as the user being created."""
+    target_organization = create_random_organization(db)
+    other_organization = create_random_organization(db)
+    role_from_other_org = get_org_role(db, other_organization.id, "system_admin")
+
+    data = {
+        "email": random_email(),
+        "password": random_lower_string(),
+        "phone": random_lower_string(),
+        "role_id": role_from_other_org.id,
+        "full_name": random_lower_string(),
+        "organization_id": target_organization.id,
+    }
+    response = client.post(
+        f"{settings.API_V1_STR}/users/",
+        headers=superuser_token_headers,
+        json=data,
+    )
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"] == "Role does not belong to the user's organization"
+    )
+
+
 def test_get_existing_user(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
@@ -961,6 +988,45 @@ def test_update_user(
     db.refresh(user_db)
     assert user_db
     assert user_db.full_name == "Updated_full_name"
+
+
+def test_update_user_role_from_different_organization(
+    client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
+) -> None:
+    """A role must belong to the user's own organization, even on update -
+    it's checked against the target user's organization, not the payload's."""
+    organization = create_random_organization(db)
+    other_organization = create_random_organization(db)
+
+    role = get_org_role(db, organization.id, "test_admin")
+    user_in = UserCreate(
+        email=random_email(),
+        password=random_lower_string(),
+        full_name=random_lower_string(),
+        phone=random_lower_string(),
+        role_id=role.id,
+        organization_id=organization.id,
+    )
+    user = crud.create_user(session=db, user_create=user_in)
+
+    role_from_other_org = get_org_role(db, other_organization.id, "test_admin")
+    data = {
+        "email": user_in.email,
+        "password": user_in.password,
+        "full_name": user_in.full_name,
+        "phone": user_in.phone,
+        "role_id": role_from_other_org.id,
+        "organization_id": organization.id,
+    }
+    response = client.patch(
+        f"{settings.API_V1_STR}/users/{user.id}",
+        headers=get_user_superadmin_token,
+        json=data,
+    )
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"] == "Role does not belong to the user's organization"
+    )
 
 
 def test_update_user_not_exists(

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -1016,7 +1016,7 @@ def test_update_user_role_from_different_organization(
         "full_name": user_in.full_name,
         "phone": user_in.phone,
         "role_id": role_from_other_org.id,
-        "organization_id": organization.id,
+        "organization_id": other_organization.id,
     }
     response = client.patch(
         f"{settings.API_V1_STR}/users/{user.id}",

--- a/backend/app/tests/api/routes/test_user.py
+++ b/backend/app/tests/api/routes/test_user.py
@@ -31,7 +31,7 @@ from app.models.user import UserState
 from app.tests.utils.organization import (
     create_random_organization,
 )
-from app.tests.utils.role import create_random_role
+from app.tests.utils.role import create_random_role, get_org_role
 from app.tests.utils.user import (
     authentication_token_from_email,
     create_random_user,
@@ -103,10 +103,9 @@ def test_create_user_new_email(
         password = random_lower_string()
         phone = random_lower_string()
 
-        # use a role from the hierarchy instead of random role
-        role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-        assert role is not None
         organization = create_random_organization(db)
+        # use a role from the hierarchy instead of random role
+        role = get_org_role(db, organization.id, "system_admin")
         data = {
             "email": username,
             "password": password,
@@ -145,9 +144,9 @@ def test_create_user_new_email_without_org_id(
         password = random_lower_string()
         phone = random_lower_string()
 
+        current_user_data = get_current_user_data(client, superuser_token_headers)
         # use a role from the hierarchy instead of random role
-        role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-        assert role is not None
+        role = get_org_role(db, current_user_data["organization_id"], "system_admin")
 
         data = {
             "email": username,
@@ -169,7 +168,6 @@ def test_create_user_new_email_without_org_id(
         assert user
         assert user.email == created_user["email"]
 
-        current_user_data = get_current_user_data(client, superuser_token_headers)
         expected_org_id = current_user_data["organization_id"]
         assert user.organization_id == expected_org_id
         assert created_user["organization_id"] == expected_org_id
@@ -925,10 +923,10 @@ def test_update_user(
 ) -> None:
     username = random_email()
     password = random_lower_string()
+    organization = create_random_organization(db)
 
     # use a role from the hierarchy instead of random role
-    role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert role is not None
+    role = get_org_role(db, organization.id, "test_admin")
 
     user_in = UserCreate(
         email=username,
@@ -936,7 +934,7 @@ def test_update_user(
         full_name=random_lower_string(),
         phone=random_lower_string(),
         role_id=role.id,
-        organization_id=create_random_organization(db).id,
+        organization_id=organization.id,
     )
     user = crud.create_user(session=db, user_create=user_in)
 
@@ -1167,11 +1165,10 @@ def test_create_inactive_user_not_listed(
     full_name = random_lower_string()
     phone = random_lower_string()
 
-    # use a role from the hierarchy instead of random role
-    role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert role is not None
-
     organization = create_random_organization(db)
+    # use a role from the hierarchy instead of random role
+    role = get_org_role(db, organization.id, "test_admin")
+
     data = {
         "email": username,
         "password": password,
@@ -1212,9 +1209,8 @@ def test_create_state_admin_without_state_id_district_id(
         full_name = random_lower_string()
         password = random_lower_string()
         phone = random_lower_string()
-        role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-        assert role is not None
         organization = create_random_organization(db)
+        role = get_org_role(db, organization.id, "state_admin")
         data = {
             "email": email,
             "password": password,
@@ -1251,8 +1247,7 @@ def test_create_state_admin_with_state_id(
         full_name = random_lower_string()
         password = random_lower_string()
         phone = random_lower_string()
-        role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-        assert role is not None
+        role = get_org_role(db, org_id, "state_admin")
         country = Country(name=random_lower_string(), is_active=True)
         db.add(country)
         db.commit()
@@ -1325,8 +1320,7 @@ def test_create_state_admin_with_district_id(
         full_name = random_lower_string()
         password = random_lower_string()
         phone = random_lower_string()
-        role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-        assert role is not None
+        role = get_org_role(db, org_id, "state_admin")
         country = Country(name=random_lower_string(), is_active=True)
         db.add(country)
         db.commit()
@@ -1413,8 +1407,7 @@ def test_create_user_multiple_state_assignment_error(
         full_name = random_lower_string()
         password = random_lower_string()
         phone = random_lower_string()
-        role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-        assert role is not None
+        role = get_org_role(db, org_id, "test_admin")
 
         data = {
             "email": email,
@@ -1471,8 +1464,7 @@ def test_create_user_multiple_district_assignment(
         full_name = random_lower_string()
         password = random_lower_string()
         phone = random_lower_string()
-        role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-        assert role is not None
+        role = get_org_role(db, org_id, "test_admin")
 
         data = {
             "email": email,
@@ -1522,8 +1514,7 @@ def test_create_test_admin_single_state_success(
         full_name = random_lower_string()
         password = random_lower_string()
         phone = random_lower_string()
-        role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-        assert role is not None
+        role = get_org_role(db, org_id, "test_admin")
 
         data = {
             "email": email,
@@ -1578,8 +1569,7 @@ def test_create_test_admin_single_district_success(
         full_name = random_lower_string()
         password = random_lower_string()
         phone = random_lower_string()
-        role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-        assert role is not None
+        role = get_org_role(db, org_id, "test_admin")
 
         data = {
             "email": email,
@@ -1618,8 +1608,7 @@ def test_create_user_without_states(
         password = random_lower_string()
         phone = random_lower_string()
 
-        role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-        assert role is not None
+        role = get_org_role(db, org_id, "test_admin")
 
         data = {
             "email": email,
@@ -1659,8 +1648,7 @@ def test_update_user_states(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
     org = create_random_organization(db)
-    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "system_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -1746,8 +1734,7 @@ def test_update_user_districts(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
     org = create_random_organization(db)
-    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "system_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -1784,8 +1771,7 @@ def test_update_user_districts(
     assert response.status_code == 200
     user_data = response.json()
     user_id = user_data["id"]
-    role1 = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert role1 is not None
+    role1 = get_org_role(db, org.id, "state_admin")
     assert user_data["districts"] is None
     email = random_email()
     password = random_lower_string()
@@ -1862,11 +1848,8 @@ def test_update_other_role_to_state_admin_and_add_states(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
     org = create_random_organization(db)
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-
-    other_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert state_admin_role is not None
-    assert other_role is not None
+    state_admin_role = get_org_role(db, org.id, "state_admin")
+    other_role = get_org_role(db, org.id, "test_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -1922,11 +1905,8 @@ def test_update_other_role_to_state_admin_and_add_districts(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
     org = create_random_organization(db)
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-
-    other_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert state_admin_role is not None
-    assert other_role is not None
+    state_admin_role = get_org_role(db, org.id, "state_admin")
+    other_role = get_org_role(db, org.id, "test_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -1994,11 +1974,8 @@ def test_update_other_role_to_state_admin_without_state_ids_returns_400(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
     org = create_random_organization(db)
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-
-    other_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert state_admin_role is not None
-    assert other_role is not None
+    state_admin_role = get_org_role(db, org.id, "state_admin")
+    other_role = get_org_role(db, org.id, "test_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -2052,11 +2029,8 @@ def test_update_other_role_to_state_admin_without_district_ids_returns_400(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
     org = create_random_organization(db)
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-
-    other_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert state_admin_role is not None
-    assert other_role is not None
+    state_admin_role = get_org_role(db, org.id, "state_admin")
+    other_role = get_org_role(db, org.id, "test_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -2117,11 +2091,8 @@ def test_update_state_admin_to_other_role_and_remove_states(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
     org = create_random_organization(db)
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-
-    other_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert state_admin_role is not None
-    assert other_role is not None
+    state_admin_role = get_org_role(db, org.id, "state_admin")
+    other_role = get_org_role(db, org.id, "test_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -2181,11 +2152,8 @@ def test_update_state_admin_to_other_role_and_remove_districts(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
     org = create_random_organization(db)
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-
-    other_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert state_admin_role is not None
-    assert other_role is not None
+    state_admin_role = get_org_role(db, org.id, "state_admin")
+    other_role = get_org_role(db, org.id, "test_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -2250,8 +2218,7 @@ def test_cannot_delete_user_if_linked_to_question(
 ) -> None:
     org = create_random_organization(db)
 
-    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "system_admin")
 
     data = {
         "email": random_email(),
@@ -2316,12 +2283,10 @@ def test_create_test_admin_auto_inherits_state_admin_states_and_districts(
     db.commit()
     db.refresh(district)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    assert state_admin_role is not None
-    assert test_admin_role is not None
-
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
+    test_admin_role = get_org_role(db, org.id, "test_admin")
+
     state_admin_email = random_email()
     state_admin_payload = {
         "email": state_admin_email,
@@ -2416,14 +2381,10 @@ def test_state_admin_with_state_access_creates_test_admin_for_district(
         db.commit()
         db.refresh(district)
 
-        state_admin_role = db.exec(
-            select(Role).where(Role.name == "state_admin")
-        ).first()
-        test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-        assert state_admin_role is not None
-        assert test_admin_role is not None
-
         org = create_random_organization(db)
+        state_admin_role = get_org_role(db, org.id, "state_admin")
+        test_admin_role = get_org_role(db, org.id, "test_admin")
+
         state_admin_email = random_email()
 
         # Create state_admin with only state-level access (no district)
@@ -2516,10 +2477,9 @@ def test_test_admin_creates_test_admin_inherits_states_and_districts(
         db.commit()
         db.refresh(district)
 
-        test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-        assert test_admin_role is not None
-
         org = create_random_organization(db)
+        test_admin_role = get_org_role(db, org.id, "test_admin")
+
         creator_email = random_email()
 
         # Create the creator test_admin (via superadmin) with state + district
@@ -2597,11 +2557,9 @@ def test_update_normal_user_to_test_admin_with_multiple_states_should_fail(
     db.refresh(state1)
     db.refresh(state2)
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    other_role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert test_admin_role and other_role
-
     org = create_random_organization(db)
+    test_admin_role = get_org_role(db, org.id, "test_admin")
+    other_role = get_org_role(db, org.id, "system_admin")
 
     payload = {
         "email": random_email(),
@@ -2663,11 +2621,9 @@ def test_update_normal_user_to_test_admin_with_multiple_districts(
     db.commit()
     db.refresh(district_2)
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    other_role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert test_admin_role and other_role
-
     org = create_random_organization(db)
+    test_admin_role = get_org_role(db, org.id, "test_admin")
+    other_role = get_org_role(db, org.id, "system_admin")
 
     payload = {
         "email": random_email(),
@@ -2722,11 +2678,9 @@ def test_update_normal_user_to_test_admin_without_states_districts(
     db.commit()
     db.refresh(district)
 
-    test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-    other_role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert test_admin_role and other_role
-
     org = create_random_organization(db)
+    test_admin_role = get_org_role(db, org.id, "test_admin")
+    other_role = get_org_role(db, org.id, "system_admin")
 
     payload = {
         "email": random_email(),
@@ -2884,9 +2838,8 @@ def test_create_user_role_hierarchy_validation_super_admin(
 ) -> None:
     """Test that super_admin can create users with any role."""
 
-    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert role is not None
     organization = create_random_organization(session=db)
+    role = get_org_role(db, organization.id, "system_admin")
 
     data = {
         "email": random_email(),
@@ -2916,9 +2869,8 @@ def test_create_user_role_hierarchy_validation_system_admin_can_create_state_adm
     headers = get_user_token(db=db, role="system_admin")
 
     # let's create state_admin user
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
     organization = create_random_organization(session=db)
+    state_admin_role = get_org_role(db, organization.id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -2966,10 +2918,10 @@ def test_create_user_role_hierarchy_validation_system_admin_cannot_create_super_
     # get auth headers for system admin user
     headers = get_user_token(db=db, role="system_admin")
 
-    # try to create super_admin user (should fail)
+    # try to create super_admin user (should fail on role hierarchy, not org
+    # scoping, so target this user at super_admin's own organization)
     super_admin_role = db.exec(select(Role).where(Role.name == "super_admin")).first()
     assert super_admin_role is not None
-    organization = create_random_organization(session=db)
 
     data = {
         "email": random_email(),
@@ -2977,7 +2929,7 @@ def test_create_user_role_hierarchy_validation_system_admin_cannot_create_super_
         "full_name": random_lower_string(),
         "phone": random_lower_string(),
         "role_id": super_admin_role.id,
-        "organization_id": organization.id,
+        "organization_id": super_admin_role.organization_id,
     }
 
     response = client.post(
@@ -3014,8 +2966,7 @@ def test_user_list_state_user(
     db.refresh(state_x)
     db.refresh(state_y)
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role is not None
+    state_admin_role = get_org_role(db, new_organization.id, "state_admin")
 
     email = random_email()
     state_admin_payload = {
@@ -3067,11 +3018,9 @@ def test_user_list_state_user(
 def test_state_admin_cannot_delete_general_user(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-    system_admin_role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert system_admin_role
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
+    system_admin_role = get_org_role(db, org.id, "system_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -3133,9 +3082,8 @@ def test_state_admin_cannot_delete_general_user(
 def test_state_admin_cannot_delete_user_in_other_state(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -3193,9 +3141,8 @@ def test_state_admin_cannot_delete_user_in_other_state(
 def test_state_admin_cannot_delete_user_in_other_district(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -3267,9 +3214,8 @@ def test_state_admin_cannot_delete_user_in_other_district(
 def test_state_admin_can_delete_user_in_same_state(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -3325,11 +3271,9 @@ def test_state_admin_can_delete_user_in_same_state(
 def test_state_admin_cannot_update_general_user(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-    system_admin_role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert system_admin_role
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
+    system_admin_role = get_org_role(db, org.id, "system_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -3396,9 +3340,8 @@ def test_state_admin_cannot_update_general_user(
 def test_state_admin_cannot_update_user_in_other_state(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -3463,9 +3406,8 @@ def test_district_level_admin_cannot_update_user_in_other_state(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
     """State admin with district in state X cannot update user in state Y"""
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -3545,9 +3487,8 @@ def test_district_level_admin_cannot_update_user_in_other_state(
 def test_state_admin_can_update_user_in_same_state(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -3610,9 +3551,8 @@ def test_state_admin_can_update_user_in_same_state(
 def test_state_admin_can_update_user_in_same_district(
     client: TestClient, get_user_superadmin_token: dict[str, str], db: Session
 ) -> None:
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
     org = create_random_organization(db)
+    state_admin_role = get_org_role(db, org.id, "state_admin")
 
     country = Country(name=random_lower_string(), is_active=True)
     db.add(country)
@@ -3683,10 +3623,8 @@ def test_district_user_cannot_modify_out_of_scope_user(
     get_user_systemadmin_token: dict[str, str],
 ) -> None:
     """State admin with district in state X cannot modify user in state Y"""
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
-
     org = get_current_user_data(client, get_user_systemadmin_token)["organization_id"]
+    state_admin_role = get_org_role(db, org, "state_admin")
 
     country = Country(name=random_lower_string())
     db.add(country)
@@ -3843,8 +3781,7 @@ def test_get_users_by_district_user(
 
     email = random_email()
 
-    state_admin_role = db.exec(select(Role).where(Role.name == "state_admin")).first()
-    assert state_admin_role
+    state_admin_role = get_org_role(db, org_id, "state_admin")
     state_admin_user_payload = {
         "email": email,
         "password": random_lower_string(),
@@ -4072,8 +4009,7 @@ def _create_deletable_user(
 ) -> tuple[int, int]:
     """Create a system_admin user in a fresh org; return (user_id, org_id)."""
     org = create_random_organization(db)
-    role = db.exec(select(Role).where(Role.name == "system_admin")).first()
-    assert role is not None
+    role = get_org_role(db, org.id, "system_admin")
     resp = client.post(
         f"{settings.API_V1_STR}/users/",
         headers=token,
@@ -4335,10 +4271,7 @@ def test_state_admin_creates_and_updates_test_admin_district(
         db.refresh(district_z)
 
         # Create state admin scoped to state X
-        state_admin_role = db.exec(
-            select(Role).where(Role.name == "state_admin")
-        ).first()
-        assert state_admin_role is not None
+        state_admin_role = get_org_role(db, org_id, "state_admin")
 
         state_admin_email = random_email()
         state_admin_password = random_lower_string()
@@ -4366,8 +4299,7 @@ def test_state_admin_creates_and_updates_test_admin_district(
         )
 
         # Step 1: state admin creates a test admin for district Y
-        test_admin_role = db.exec(select(Role).where(Role.name == "test_admin")).first()
-        assert test_admin_role is not None
+        test_admin_role = get_org_role(db, org_id, "test_admin")
 
         r = client.post(
             f"{settings.API_V1_STR}/users/",

--- a/backend/app/tests/utils/role.py
+++ b/backend/app/tests/utils/role.py
@@ -1,8 +1,38 @@
-from sqlmodel import Session
+from sqlmodel import Session, select
 
+from app.core.roles import init_org_roles, init_super_admin_role
 from app.models import Role, RoleCreate
 from app.tests.utils.organization import create_random_organization
 from app.tests.utils.utils import random_lower_string
+
+
+def get_org_role(session: Session, organization_id: int | None, role_name: str) -> Role:
+    """
+    Return `role_name`'s copy scoped to `organization_id`, seeding that org's
+    default roles first if they don't exist yet.
+    """
+    assert organization_id is not None
+    role = session.exec(
+        select(Role).where(
+            Role.name == role_name, Role.organization_id == organization_id
+        )
+    ).first()
+    if role is None:
+        if role_name == "super_admin":
+            init_super_admin_role(session, organization_id)
+        else:
+            init_org_roles(session, organization_id)
+        role = session.exec(
+            select(Role).where(
+                Role.name == role_name, Role.organization_id == organization_id
+            )
+        ).first()
+    if role is None:
+        role = Role(name=role_name, label=role_name, organization_id=organization_id)
+        session.add(role)
+        session.commit()
+        session.refresh(role)
+    return role
 
 
 def create_random_role(session: Session, organization_id: int | None = None) -> Role:

--- a/backend/app/tests/utils/role.py
+++ b/backend/app/tests/utils/role.py
@@ -27,11 +27,7 @@ def get_org_role(session: Session, organization_id: int | None, role_name: str) 
                 Role.name == role_name, Role.organization_id == organization_id
             )
         ).first()
-    if role is None:
-        role = Role(name=role_name, label=role_name, organization_id=organization_id)
-        session.add(role)
-        session.commit()
-        session.refresh(role)
+    assert role is not None
     return role
 
 

--- a/backend/app/tests/utils/role.py
+++ b/backend/app/tests/utils/role.py
@@ -1,16 +1,24 @@
 from sqlmodel import Session
 
 from app.models import Role, RoleCreate
+from app.tests.utils.organization import create_random_organization
 from app.tests.utils.utils import random_lower_string
 
 
-def create_random_role(session: Session) -> Role:
+def create_random_role(session: Session, organization_id: int | None = None) -> Role:
+    if organization_id is None:
+        organization_id = create_random_organization(session=session).id
+        assert organization_id is not None
+
     name = random_lower_string()
     description = random_lower_string()
     label = random_lower_string()
     role_in = RoleCreate(name=name, description=description, label=label)
 
-    db_role = Role.model_validate(role_in)
+    db_role = Role(
+        **role_in.model_dump(exclude={"permissions"}),
+        organization_id=organization_id,
+    )
     session.add(db_role)
     session.commit()
     session.refresh(db_role)

--- a/backend/app/tests/utils/user.py
+++ b/backend/app/tests/utils/user.py
@@ -5,6 +5,7 @@ from sqlmodel import Session, select
 
 from app import crud
 from app.core.config import settings
+from app.core.roles import init_org_roles
 from app.models import Organization, Role, User, UserCreate, UserUpdate
 from app.tests.utils.organization import create_random_organization
 from app.tests.utils.utils import random_email, random_lower_string
@@ -23,16 +24,20 @@ def user_authentication_headers(
 
 
 def create_random_user(db: Session, organization_id: int | None = None) -> User:
-    role = Role(name=random_lower_string(), label=random_lower_string())
     if organization_id is not None:
         organization = db.get(Organization, organization_id)
         if not organization:
             raise ValueError(f"Organization with ID {organization_id} not found")
     else:
         organization = create_random_organization(session=db)
-    db.add_all([organization, role])
+    assert organization.id is not None
+    role = Role(
+        name=random_lower_string(),
+        label=random_lower_string(),
+        organization_id=organization.id,
+    )
+    db.add(role)
     db.commit()
-    db.refresh(organization)
     db.refresh(role)
     email = random_email()
     password = random_lower_string()
@@ -51,17 +56,36 @@ def create_random_user(db: Session, organization_id: int | None = None) -> User:
 
 
 def get_user_token(*, db: Session, role: str) -> dict[str, str]:
-    current_role = db.exec(select(Role).where(Role.name == role)).first()
+    if role == "super_admin":
+        current_role = db.exec(select(Role).where(Role.name == role)).first()
+        if not current_role:
+            raise Exception(f"Role with name '{role}' not found")
+        organization = Organization(
+            name=random_lower_string(), description=random_lower_string()
+        )
+        db.add(organization)
+        db.commit()
+        db.refresh(organization)
+    else:
+        organization = Organization(
+            name=random_lower_string(), description=random_lower_string()
+        )
+        db.add(organization)
+        db.commit()
+        db.refresh(organization)
+        assert organization.id is not None
+        init_org_roles(db, organization.id)
 
-    if not current_role:
-        raise Exception(f"Role with name '{role}' not found")
-
-    organization = Organization(
-        name=random_lower_string(), description=random_lower_string()
-    )
-    db.add(organization)
-    db.commit()
-    db.refresh(organization)
+        current_role = db.exec(
+            select(Role).where(
+                Role.name == role, Role.organization_id == organization.id
+            )
+        ).first()
+        if not current_role:
+            current_role = Role(name=role, label=role, organization_id=organization.id)
+            db.add(current_role)
+            db.commit()
+            db.refresh(current_role)
 
     user_in = UserCreate(
         full_name=random_lower_string(),
@@ -110,8 +134,7 @@ def authentication_token_from_email(
             password=password,
             organization_id=user.organization_id,
         )
-        if not user.id:
-            raise Exception("User id not set")
+        assert user.id is not None
         user = crud.update_user(session=db, db_user=user, user_in=user_in_update)
 
     return user_authentication_headers(client=client, email=email, password=password)

--- a/backend/app/tests/utils/user.py
+++ b/backend/app/tests/utils/user.py
@@ -5,7 +5,7 @@ from sqlmodel import Session, select
 
 from app import crud
 from app.core.config import settings
-from app.core.roles import init_org_roles
+from app.core.roles import init_org_roles, init_super_admin_role
 from app.models import Organization, Role, User, UserCreate, UserUpdate
 from app.tests.utils.organization import create_random_organization
 from app.tests.utils.utils import random_email, random_lower_string
@@ -56,36 +56,26 @@ def create_random_user(db: Session, organization_id: int | None = None) -> User:
 
 
 def get_user_token(*, db: Session, role: str) -> dict[str, str]:
+    organization = Organization(
+        name=random_lower_string(), description=random_lower_string()
+    )
+    db.add(organization)
+    db.commit()
+    db.refresh(organization)
+    assert organization.id is not None
     if role == "super_admin":
-        current_role = db.exec(select(Role).where(Role.name == role)).first()
-        if not current_role:
-            raise Exception(f"Role with name '{role}' not found")
-        organization = Organization(
-            name=random_lower_string(), description=random_lower_string()
-        )
-        db.add(organization)
-        db.commit()
-        db.refresh(organization)
+        init_super_admin_role(db, organization.id)
     else:
-        organization = Organization(
-            name=random_lower_string(), description=random_lower_string()
-        )
-        db.add(organization)
-        db.commit()
-        db.refresh(organization)
-        assert organization.id is not None
         init_org_roles(db, organization.id)
 
-        current_role = db.exec(
-            select(Role).where(
-                Role.name == role, Role.organization_id == organization.id
-            )
-        ).first()
-        if not current_role:
-            current_role = Role(name=role, label=role, organization_id=organization.id)
-            db.add(current_role)
-            db.commit()
-            db.refresh(current_role)
+    current_role = db.exec(
+        select(Role).where(Role.name == role, Role.organization_id == organization.id)
+    ).first()
+    if not current_role:
+        current_role = Role(name=role, label=role, organization_id=organization.id)
+        db.add(current_role)
+        db.commit()
+        db.refresh(current_role)
 
     user_in = UserCreate(
         full_name=random_lower_string(),


### PR DESCRIPTION
## Summary

Fixes issue: #473 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roles are now scoped to organizations, with organization details included in role responses.
  * Organization creation and sample-data setup initialize default roles.
  * Added certificate configuration and related permissions.
* **Bug Fixes**
  * Role access and modifications are restricted to the caller’s organization.
  * The `super_admin` role is protected from changes.
  * Permission access and role-permission assignments were corrected.
* **Tests**
  * Expanded coverage for organization isolation, role protection, and permission handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->