### PR TITLE
Rename external_id | Check Start of Resume of Test

### DIFF
--- a/backend/app/alembic/versions/b2f5a9c81d34_rename_external_user_id_to_external_identifier.py
+++ b/backend/app/alembic/versions/b2f5a9c81d34_rename_external_user_id_to_external_identifier.py
@@ -4,7 +4,7 @@ Renames the external-login column (and its partial unique index) from
 external_user_id to external_identifier, matching the API/model rename.
 
 Revision ID: b2f5a9c81d34
-Revises: 929353af67bf
+Revises: 803a08724747
 Create Date: 2026-07-31 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'b2f5a9c81d34'
-down_revision = '929353af67bf'
+down_revision = '803a08724747'
 branch_labels = None
 depends_on = None
 

--- a/backend/app/alembic/versions/b2f5a9c81d34_rename_external_user_id_to_external_identifier.py
+++ b/backend/app/alembic/versions/b2f5a9c81d34_rename_external_user_id_to_external_identifier.py
@@ -1,0 +1,36 @@
+"""Rename candidate.external_user_id to external_identifier
+
+Renames the external-login column (and its partial unique index) from
+external_user_id to external_identifier, matching the API/model rename.
+
+Revision ID: b2f5a9c81d34
+Revises: 929353af67bf
+Create Date: 2026-07-31 00:00:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2f5a9c81d34'
+down_revision = '929353af67bf'
+branch_labels = None
+depends_on = None
+
+
+OLD_INDEX = "uq_candidate_org_external_user_id"
+NEW_INDEX = "uq_candidate_org_external_identifier"
+
+
+def upgrade():
+    op.alter_column(
+        'candidate', 'external_user_id', new_column_name='external_identifier'
+    )
+    op.execute(f'ALTER INDEX {OLD_INDEX} RENAME TO {NEW_INDEX}')
+
+
+def downgrade():
+    op.execute(f'ALTER INDEX {NEW_INDEX} RENAME TO {OLD_INDEX}')
+    op.alter_column(
+        'candidate', 'external_identifier', new_column_name='external_user_id'
+    )

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -891,35 +891,20 @@ def _get_or_create_external_candidate(
     return candidate
 
 
-def _get_or_create_candidate_test(
-    session: SessionDep,
-    *,
-    test: Test,
-    candidate: Candidate,
-    admin_id: int,
-    start_test_request: StartTestRequest,
-) -> CandidateTest:
-    """Find the candidate's existing attempt for this test, or create one.
+def _find_candidate_test(
+    session: SessionDep, *, test: Test, candidate: Candidate
+) -> CandidateTest | None:
+    """The candidate's existing attempt for this test, if any.
 
     A reused candidate may already have a CandidateTest for this test (the
     UNIQUE(test_id, candidate_id) constraint enforces one attempt per pair), so
-    re-provisioning must be idempotent rather than raising a unique violation.
+    starting again must resolve that attempt rather than raise a unique violation.
     """
-    existing = session.exec(
+    return session.exec(
         select(CandidateTest)
         .where(CandidateTest.test_id == test.id)
         .where(CandidateTest.candidate_id == candidate.id)
     ).first()
-    if existing is not None:
-        return existing
-
-    return _create_candidate_test(
-        session,
-        test=test,
-        candidate=candidate,
-        admin_id=admin_id,
-        start_test_request=start_test_request,
-    )
 
 
 def _get_external_login_value(session: SessionDep, test: Test) -> Any | None:
@@ -994,17 +979,23 @@ def start_test_for_candidate(
         _require_external_login_enabled(session, test)
         _validate_test_start_window(session, test)
         candidate = _get_provisioned_candidate(session, test, candidate_uuid)
-        candidate_test = _get_or_create_candidate_test(
-            session,
-            test=test,
-            candidate=candidate,
-            admin_id=admin_id,
-            start_test_request=start_test_request,
-        )
+        # The attempt is created on the first start, so finding one here means the
+        # candidate already started this test — on this device or another.
+        candidate_test = _find_candidate_test(session, test=test, candidate=candidate)
+        is_resumed = candidate_test is not None
+        if candidate_test is None:
+            candidate_test = _create_candidate_test(
+                session,
+                test=test,
+                candidate=candidate,
+                admin_id=admin_id,
+                start_test_request=start_test_request,
+            )
         return StartTestResponse(
             candidate_uuid=candidate_uuid,
             candidate_test_id=candidate_test.id,
             is_submitted=candidate_test.is_submitted,
+            is_resumed=is_resumed,
         )
 
     if _should_block_anonymous_start(session, test):

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -865,9 +865,9 @@ def _create_anonymous_candidate(session: SessionDep, test: Test) -> Candidate:
 
 
 def _get_or_create_external_candidate(
-    session: SessionDep, test: Test, external_user_id: str
+    session: SessionDep, test: Test, external_identifier: str
 ) -> Candidate:
-    """Reuse a single candidate per (organization, external_user_id).
+    """Reuse a single candidate per (organization, external_identifier).
 
     Unlike anonymous QR candidates (a fresh row per start), an external user is a
     recurring student: the same candidate is returned across all their tests.
@@ -875,7 +875,7 @@ def _get_or_create_external_candidate(
     candidate = session.exec(
         select(Candidate)
         .where(Candidate.organization_id == test.organization_id)
-        .where(Candidate.external_user_id == external_user_id)
+        .where(Candidate.external_identifier == external_identifier)
     ).first()
     if candidate is not None:
         return candidate
@@ -883,7 +883,7 @@ def _get_or_create_external_candidate(
     candidate = Candidate(
         identity=uuid.uuid4(),
         organization_id=test.organization_id,
-        external_user_id=external_user_id,
+        external_identifier=external_identifier,
     )
     session.add(candidate)
     session.flush()  # assigns candidate.id without committing; committed with the test
@@ -1043,7 +1043,7 @@ def provision_external_candidate_test(
     _validate_test_start_window(session, test)
 
     candidate = _get_or_create_external_candidate(
-        session, test, provision_request.external_user_id
+        session, test, provision_request.external_identifier
     )
     candidate_test = _get_or_create_candidate_test(
         session,
@@ -2354,7 +2354,7 @@ def compute_result(
         total_questions=total_questions,
         marks_obtained=marks_obtained if has_marking_scheme else None,
         marks_maximum=marks_maximum if has_marking_scheme else None,
-        external_user_id=candidate.external_user_id if candidate else None,
+        external_identifier=candidate.external_identifier if candidate else None,
     )
 
 

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -934,11 +934,8 @@ def _get_external_login_value(session: SessionDep, test: Test) -> Any | None:
 
 
 def _should_block_anonymous_start(session: SessionDep, test: Test) -> bool:
-    external_login = _get_external_login_value(session, test)
-    return bool(
-        external_login
-        and external_login.enabled
-        and external_login.block_anonymous_starts
+    return crud_settings.blocks_anonymous_starts(
+        session=session, organization_id=test.organization_id
     )
 
 

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -62,6 +62,7 @@ from app.models.candidate import (
     CandidateTimerSyncRequest,
     DeleteCandidate,
     ExternalProvisionRequest,
+    ExternalProvisionResponse,
     OverallTestAnalyticsResponse,
     Result,
     StartTestRequest,
@@ -886,7 +887,7 @@ def _get_or_create_external_candidate(
         external_identifier=external_identifier,
     )
     session.add(candidate)
-    session.flush()  # assigns candidate.id without committing; committed with the test
+    session.flush()  # assigns candidate.id; the caller commits
     return candidate
 
 
@@ -950,27 +951,25 @@ def _require_external_login_enabled(session: SessionDep, test: Test) -> None:
         )
 
 
-def _get_candidate_test_by_uuid(
+def _get_provisioned_candidate(
     session: SessionDep, test: Test, candidate_uuid: uuid.UUID
-) -> CandidateTest:
-    """Resume a previously provisioned attempt for this test.
+) -> Candidate:
+    """Look up the externally provisioned candidate behind this identity.
 
-    Scoping by test_id plus the unguessable candidate identity is sufficient
-    authorization here, so unlike verify_candidate_uuid_access this does not
-    also need the candidate_test_id as a second factor.
+    The unguessable identity, scoped to the test's organization, is sufficient
+    authorization here.
     """
-    candidate_test = session.exec(
-        select(CandidateTest)
-        .join(Candidate)
-        .where(CandidateTest.test_id == test.id)
+    candidate = session.exec(
+        select(Candidate)
         .where(Candidate.identity == candidate_uuid)
+        .where(Candidate.organization_id == test.organization_id)
     ).first()
-    if not candidate_test:
+    if not candidate:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Candidate test not found or invalid UUID",
+            detail="Candidate not found or invalid UUID",
         )
-    return candidate_test
+    return candidate
 
 
 @router.post("/start_test", response_model=StartTestResponse)
@@ -986,8 +985,9 @@ def start_test_for_candidate(
     Creates a candidate when they start a test, links them to the test.
     Returns the candidate UUID for verification.
 
-    If candidate_uuid is provided, resumes an existing externally-provisioned
-    attempt (see /external/provision) instead of creating a new anonymous one.
+    If candidate_uuid is provided, starts (or resumes) the test for that
+    externally provisioned candidate (see /external/provision) instead of
+    creating a new anonymous one.
     """
     test, admin_id = _resolve_active_test_link(
         session, start_test_request.test_link_uuid
@@ -996,7 +996,14 @@ def start_test_for_candidate(
     if candidate_uuid is not None:
         _require_external_login_enabled(session, test)
         _validate_test_start_window(session, test)
-        candidate_test = _get_candidate_test_by_uuid(session, test, candidate_uuid)
+        candidate = _get_provisioned_candidate(session, test, candidate_uuid)
+        candidate_test = _get_or_create_candidate_test(
+            session,
+            test=test,
+            candidate=candidate,
+            admin_id=admin_id,
+            start_test_request=start_test_request,
+        )
         return StartTestResponse(
             candidate_uuid=candidate_uuid,
             candidate_test_id=candidate_test.id,
@@ -1024,14 +1031,18 @@ def start_test_for_candidate(
     )
 
 
-@router.post("/external/provision", response_model=StartTestResponse)
+@router.post("/external/provision", response_model=ExternalProvisionResponse)
 def provision_external_candidate_test(
     session: SessionDep,
     current_user: CurrentUser,
     provision_request: ExternalProvisionRequest = Body(...),
-) -> StartTestResponse:
-    """Create the Sashakt candidate and attempt Organization will map to its user."""
-    test, admin_id = _resolve_active_test_link(
+) -> ExternalProvisionResponse:
+    """Resolve the Sashakt candidate an organization's external identifier maps to.
+
+    Only the candidate is provisioned. The attempt is created when the candidate
+    starts the test, so an existing attempt always means they have started it.
+    """
+    test, _admin_id = _resolve_active_test_link(
         session, provision_request.test_link_uuid
     )
     if test.organization_id != current_user.organization_id:
@@ -1045,18 +1056,8 @@ def provision_external_candidate_test(
     candidate = _get_or_create_external_candidate(
         session, test, provision_request.external_identifier
     )
-    candidate_test = _get_or_create_candidate_test(
-        session,
-        test=test,
-        candidate=candidate,
-        admin_id=admin_id,
-        start_test_request=provision_request,
-    )
-    return StartTestResponse(
-        candidate_uuid=candidate.identity,
-        candidate_test_id=candidate_test.id,
-        is_submitted=candidate_test.is_submitted,
-    )
+    session.commit()
+    return ExternalProvisionResponse(candidate_uuid=candidate.identity)
 
 
 def verify_candidate_uuid_access(

--- a/backend/app/api/routes/test.py
+++ b/backend/app/api/routes/test.py
@@ -909,6 +909,9 @@ def get_public_test_info(test_uuid: str, session: SessionDep) -> TestPublicLimit
         form=form_public,
         nomenclature=nomenclature,
         link=test_uuid,
+        blocks_anonymous_start=crud_settings.blocks_anonymous_starts(
+            session=session, organization_id=test.organization_id
+        ),
     )
 
 

--- a/backend/app/crud/organization_settings.py
+++ b/backend/app/crud/organization_settings.py
@@ -31,6 +31,25 @@ def get_payload(
     return OrganizationSettingsPayload.model_validate(row.settings)
 
 
+def blocks_anonymous_starts(*, session: Session, organization_id: int | None) -> bool:
+    """Whether this org requires candidates to arrive from their student portal.
+
+    Used both to reject an anonymous start and to tell the landing page not to
+    offer one in the first place.
+    """
+    if organization_id is None:
+        return False
+    payload = get_payload(session=session, organization_id=organization_id)
+    if payload is None:
+        return False
+    external_login = payload.external_login.value
+    return bool(
+        external_login
+        and external_login.enabled
+        and external_login.block_anonymous_starts
+    )
+
+
 def _insert_or_return_existing(
     *,
     session: Session,

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -386,6 +386,16 @@ class ExternalProvisionRequest(StartTestRequest):
     external_identifier: str
 
 
+class ExternalProvisionResponse(SQLModel):
+    """The candidate an external identifier maps to.
+
+    Only the candidate is provisioned; the attempt is created when the candidate
+    actually starts the test, exactly as in the anonymous flow.
+    """
+
+    candidate_uuid: uuid.UUID
+
+
 class OverallTestAnalyticsResponse(SQLModel):
     total_candidates: int
     overall_score_percent: float

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -382,7 +382,15 @@ class StartTestResponse(SQLModel):
     is_submitted: bool = False
 
 
-class ExternalProvisionRequest(StartTestRequest):
+class ExternalProvisionRequest(SQLModel):
+    """Resolve a candidate for an external identifier.
+
+    Deliberately not a StartTestRequest: provisioning only resolves the
+    candidate, so device info and form responses have nowhere to go. They are
+    sent with the actual start_test call instead.
+    """
+
+    test_link_uuid: str
     external_identifier: str
 
 

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -383,23 +383,14 @@ class StartTestResponse(SQLModel):
 
 
 class ExternalProvisionRequest(SQLModel):
-    """Resolve a candidate for an external identifier.
-
-    Deliberately not a StartTestRequest: provisioning only resolves the
-    candidate, so device info and form responses have nowhere to go. They are
-    sent with the actual start_test call instead.
-    """
+    """Resolve a candidate for an external identifier."""
 
     test_link_uuid: str
     external_identifier: str
 
 
 class ExternalProvisionResponse(SQLModel):
-    """The candidate an external identifier maps to.
-
-    Only the candidate is provisioned; the attempt is created when the candidate
-    actually starts the test, exactly as in the anonymous flow.
-    """
+    """The candidate an external identifier maps to. Here only the candidate is provisioned."""
 
     candidate_uuid: uuid.UUID
 

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -380,6 +380,7 @@ class StartTestResponse(SQLModel):
     candidate_uuid: uuid.UUID
     candidate_test_id: int
     is_submitted: bool = False
+    is_resumed: bool = False  # True when this launch returned an already-started attempt by an external user
 
 
 class ExternalProvisionRequest(SQLModel):

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -252,9 +252,9 @@ class Candidate(CandidateBase, table=True):
     identity: uuid.UUID | None = Field(
         default=None, unique=True, index=True, nullable=True
     )  # Only for anonymous QR code users
-    external_user_id: str | None = Field(
+    external_identifier: str | None = Field(
         default=None
-    )  # External (e.g. Avanti) user id; reused across tests per (organization, external_user_id).
+    )  # External (e.g. Avanti) user id; reused across tests per (organization, external_identifier).
     # Uniqueness + lookup covered by the partial unique index in the migration.
     created_date: datetime | None = Field(default_factory=get_timezone_aware_now)
     modified_date: datetime | None = Field(
@@ -360,7 +360,7 @@ class Result(SQLModel):
     certificate_download_url: str | None = None
     # External (e.g. Avanti) user id, when the candidate came via external login;
     # None for anonymous QR candidates.
-    external_user_id: str | None = None
+    external_identifier: str | None = None
 
 
 class TestStatusSummary(SQLModel):
@@ -383,7 +383,7 @@ class StartTestResponse(SQLModel):
 
 
 class ExternalProvisionRequest(StartTestRequest):
-    external_user_id: str
+    external_identifier: str
 
 
 class OverallTestAnalyticsResponse(SQLModel):

--- a/backend/app/models/test.py
+++ b/backend/app/models/test.py
@@ -485,3 +485,7 @@ class TestPublicLimited(TestBase):
     question_sets: list["QuestionSetSummaryPublic"] | None = None
     form: "FormPublic | None" = None
     nomenclature: dict[str, str] = Field(default_factory=dict)
+    # True when the org requires candidates to arrive from their student portal,
+    # so the landing page can say so up front instead of letting them fill in a
+    # form and only then be turned away.
+    blocks_anonymous_start: bool = False

--- a/backend/app/models/test.py
+++ b/backend/app/models/test.py
@@ -485,7 +485,4 @@ class TestPublicLimited(TestBase):
     question_sets: list["QuestionSetSummaryPublic"] | None = None
     form: "FormPublic | None" = None
     nomenclature: dict[str, str] = Field(default_factory=dict)
-    # True when the org requires candidates to arrive from their student portal,
-    # so the landing page can say so up front instead of letting them fill in a
-    # form and only then be turned away.
-    blocks_anonymous_start: bool = False
+    blocks_anonymous_start: bool = False  # True when the org requires candidates to arrive from their student portal,

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -15982,6 +15982,45 @@ def test_start_test_rejects_anonymous_for_external_login_org(
     )
 
 
+def test_public_test_info_flags_orgs_that_block_anonymous_starts(
+    client: TestClient, db: SessionDep
+) -> None:
+    """The landing payload says so up front, so the client need not offer a start.
+
+    Without this the candidate only learns they came the wrong way after
+    filling in the pre-test form.
+    """
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.id is not None
+
+    user = create_random_user(db, organization_id=org.id)
+    assert user.id is not None
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        organization_id=org.id,
+    )
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
+
+    # Default settings: anonymous starts are allowed.
+    before = client.get(f"{settings.API_V1_STR}/test/public/{test_link.uuid}")
+    assert before.status_code == 200
+    assert before.json()["blocks_anonymous_start"] is False
+
+    enable_external_org_login(db, organization_id=org.id)
+
+    after = client.get(f"{settings.API_V1_STR}/test/public/{test_link.uuid}")
+    assert after.status_code == 200
+    assert after.json()["blocks_anonymous_start"] is True
+
+
 def test_anonymous_start_test_leaves_external_identifier_null(
     client: TestClient, db: SessionDep
 ) -> None:

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -16200,7 +16200,9 @@ def test_external_provision_and_start_resume_same_attempt(
     candidate_test = db.get(CandidateTest, first["candidate_test_id"])
     assert candidate_test is not None
     assert candidate_test.test_id == test.id
-    assert start() == first
+    assert first["is_resumed"] is False
+    # Launching again finds the existing attempt, which is exactly a resume.
+    assert start() == {**first, "is_resumed": True}
 
 
 def test_external_provision_resumes_position_and_answers_cross_device(
@@ -16307,7 +16309,8 @@ def test_external_provision_resumes_position_and_answers_cross_device(
     )
 
     # --- device B: same external user logs in again -> same candidate + attempt ---
-    assert portal_launch() == launch  # same candidate_uuid + candidate_test_id reused
+    # Same candidate + attempt reused, and reported as a resume this time.
+    assert portal_launch() == {**launch, "is_resumed": True}
 
     # device B: resume payload carries the saved position and answers
     resume = client.get(

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -16039,7 +16039,6 @@ def test_external_provision_requires_sashakt_auth(
         json={
             "test_link_uuid": test_link.uuid,
             "external_identifier": "375220",
-            "device_info": "Portal",
         },
     )
 
@@ -16051,7 +16050,6 @@ def test_external_provision_requires_sashakt_auth(
         json={
             "test_link_uuid": test_link.uuid,
             "external_identifier": "375220",
-            "device_info": "Portal",
         },
         headers={"Authorization": "Bearer wrong-token"},
     )
@@ -16090,7 +16088,6 @@ def test_external_provision_requires_external_login_enabled(
         json={
             "test_link_uuid": test_link.uuid,
             "external_identifier": "375220",
-            "device_info": "Portal",
         },
         headers=token_headers,
     )
@@ -16132,7 +16129,6 @@ def test_external_provision_and_start_resume_same_attempt(
         json={
             "test_link_uuid": test_link.uuid,
             "external_identifier": "375220",
-            "device_info": "Portal",
         },
         headers=token_headers,
     )
@@ -16324,7 +16320,6 @@ def test_external_start_reports_submitted_attempt(
         json={
             "test_link_uuid": test_link.uuid,
             "external_identifier": "375220",
-            "device_info": "Portal",
         },
         headers=token_headers,
     )
@@ -16564,7 +16559,6 @@ def test_external_start_gives_a_separate_attempt_per_test(
         json={
             "test_link_uuid": test_a_link.uuid,
             "external_identifier": "375220",
-            "device_info": "Portal",
         },
         headers=token_headers,
     )

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -15982,10 +15982,10 @@ def test_start_test_rejects_anonymous_for_external_login_org(
     )
 
 
-def test_anonymous_start_test_leaves_external_user_id_null(
+def test_anonymous_start_test_leaves_external_identifier_null(
     client: TestClient, db: SessionDep
 ) -> None:
-    """The QR/anonymous flow must be untouched: no external_user_id is stored."""
+    """The QR/anonymous flow must be untouched: no external_identifier is stored."""
     user = create_random_user(db)
     assert user.id is not None
     test = Test(
@@ -16008,7 +16008,7 @@ def test_anonymous_start_test_leaves_external_user_id_null(
     assert candidate_test is not None
     candidate = db.get(Candidate, candidate_test.candidate_id)
     assert candidate is not None
-    assert candidate.external_user_id is None
+    assert candidate.external_identifier is None
 
 
 def test_external_provision_requires_sashakt_auth(
@@ -16038,7 +16038,7 @@ def test_external_provision_requires_sashakt_auth(
         f"{settings.API_V1_STR}/candidate/external/provision",
         json={
             "test_link_uuid": test_link.uuid,
-            "external_user_id": "375220",
+            "external_identifier": "375220",
             "device_info": "Portal",
         },
     )
@@ -16050,7 +16050,7 @@ def test_external_provision_requires_sashakt_auth(
         f"{settings.API_V1_STR}/candidate/external/provision",
         json={
             "test_link_uuid": test_link.uuid,
-            "external_user_id": "375220",
+            "external_identifier": "375220",
             "device_info": "Portal",
         },
         headers={"Authorization": "Bearer wrong-token"},
@@ -16089,7 +16089,7 @@ def test_external_provision_requires_external_login_enabled(
         f"{settings.API_V1_STR}/candidate/external/provision",
         json={
             "test_link_uuid": test_link.uuid,
-            "external_user_id": "375220",
+            "external_identifier": "375220",
             "device_info": "Portal",
         },
         headers=token_headers,
@@ -16131,7 +16131,7 @@ def test_external_provision_and_start_resume_same_attempt(
         f"{settings.API_V1_STR}/candidate/external/provision",
         json={
             "test_link_uuid": test_link.uuid,
-            "external_user_id": "375220",
+            "external_identifier": "375220",
             "device_info": "Portal",
         },
         headers=token_headers,
@@ -16161,7 +16161,7 @@ def test_external_provision_resumes_position_and_answers_cross_device(
 ) -> None:
     """The genuine cross-device story: an external user starts a test on one
     device (answers a question, navigates), then logs in from another device.
-    Re-provisioning the same external_user_id returns the *same* candidate and
+    Re-provisioning the same external_identifier returns the *same* candidate and
     in-progress attempt, and the resume payload carries the saved position and
     answers — so external login + maintain-candidate-state compose end to end.
     """
@@ -16208,12 +16208,15 @@ def test_external_provision_resumes_position_and_answers_cross_device(
     token_headers = authentication_token_from_email(
         client=client, email=user.email, db=db
     )
-    external_user_id = "375220"
+    external_identifier = "375220"
 
     # --- device A: portal launch provisions the attempt ---
     device_a = client.post(
         f"{settings.API_V1_STR}/candidate/external/provision",
-        json={"test_link_uuid": test_link.uuid, "external_user_id": external_user_id},
+        json={
+            "test_link_uuid": test_link.uuid,
+            "external_identifier": external_identifier,
+        },
         headers=token_headers,
     )
     assert device_a.status_code == 200
@@ -16248,7 +16251,10 @@ def test_external_provision_resumes_position_and_answers_cross_device(
     # --- device B: same external user logs in again -> same candidate + attempt ---
     device_b = client.post(
         f"{settings.API_V1_STR}/candidate/external/provision",
-        json={"test_link_uuid": test_link.uuid, "external_user_id": external_user_id},
+        json={
+            "test_link_uuid": test_link.uuid,
+            "external_identifier": external_identifier,
+        },
         headers=token_headers,
     )
     assert device_b.status_code == 200
@@ -16303,7 +16309,7 @@ def test_external_start_reports_submitted_attempt(
         f"{settings.API_V1_STR}/candidate/external/provision",
         json={
             "test_link_uuid": test_link.uuid,
-            "external_user_id": "375220",
+            "external_identifier": "375220",
             "device_info": "Portal",
         },
         headers=token_headers,
@@ -16367,12 +16373,12 @@ def test_external_provision_reuses_same_candidate_across_tests(
         client=client, email=user.email, db=db
     )
 
-    external_user_id = "375220"
+    external_identifier = "375220"
     first_response = client.post(
         f"{settings.API_V1_STR}/candidate/external/provision",
         json={
             "test_link_uuid": test_a_link.uuid,
-            "external_user_id": external_user_id,
+            "external_identifier": external_identifier,
             "device_info": "Portal",
         },
         headers=token_headers,
@@ -16384,7 +16390,7 @@ def test_external_provision_reuses_same_candidate_across_tests(
         f"{settings.API_V1_STR}/candidate/external/provision",
         json={
             "test_link_uuid": test_b_link.uuid,
-            "external_user_id": external_user_id,
+            "external_identifier": external_identifier,
             "device_info": "Portal",
         },
         headers=token_headers,
@@ -16433,7 +16439,7 @@ def test_external_provision_is_idempotent_for_same_user_and_test(
 
     body = {
         "test_link_uuid": test_link.uuid,
-        "external_user_id": "375220",
+        "external_identifier": "375220",
         "device_info": "Portal",
     }
     first_data = client.post(
@@ -16480,12 +16486,12 @@ def test_external_provision_distinct_users_get_distinct_candidates(
 
     first_data = client.post(
         f"{settings.API_V1_STR}/candidate/external/provision",
-        json={"test_link_uuid": test_link.uuid, "external_user_id": "111"},
+        json={"test_link_uuid": test_link.uuid, "external_identifier": "111"},
         headers=token_headers,
     ).json()
     second_data = client.post(
         f"{settings.API_V1_STR}/candidate/external/provision",
-        json={"test_link_uuid": test_link.uuid, "external_user_id": "222"},
+        json={"test_link_uuid": test_link.uuid, "external_identifier": "222"},
         headers=token_headers,
     ).json()
 
@@ -16531,7 +16537,7 @@ def test_external_start_rejects_candidate_test_for_other_test(
         f"{settings.API_V1_STR}/candidate/external/provision",
         json={
             "test_link_uuid": test_a_link.uuid,
-            "external_user_id": "375220",
+            "external_identifier": "375220",
             "device_info": "Portal",
         },
         headers=token_headers,
@@ -16679,7 +16685,7 @@ def test_start_test_anonymous_allowed_when_anonymous_starts_not_blocked(
     assert candidate_test is not None
     candidate = db.get(Candidate, candidate_test.candidate_id)
     assert candidate is not None
-    assert candidate.external_user_id is None
+    assert candidate.external_identifier is None
 
 
 def test_start_test_resume_respects_start_window(
@@ -16708,7 +16714,7 @@ def test_start_test_resume_respects_start_window(
     test_link = get_test_link(db, test_id=test.id, admin_id=user.id)
 
     candidate = Candidate(
-        identity=uuid.uuid4(), organization_id=org.id, external_user_id="375220"
+        identity=uuid.uuid4(), organization_id=org.id, external_identifier="375220"
     )
     db.add(candidate)
     db.commit()

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -16137,23 +16137,35 @@ def test_external_provision_and_start_resume_same_attempt(
         headers=token_headers,
     )
     assert provision_response.status_code == 200
-    provision_data = provision_response.json()
+    candidate_uuid = provision_response.json()["candidate_uuid"]
 
-    candidate_test = db.get(CandidateTest, provision_data["candidate_test_id"])
-    assert candidate_test is not None
-    assert candidate_test.test_id == test.id
-
-    start_response = client.post(
-        f"{settings.API_V1_STR}/candidate/start_test",
-        params={"candidate_uuid": provision_data["candidate_uuid"]},
-        json={
-            "test_link_uuid": test_link.uuid,
-            "device_info": "Mobile",
-        },
+    # Provisioning only resolves the candidate; no attempt exists yet.
+    assert (
+        db.exec(
+            select(CandidateTest)
+            .join(Candidate)
+            .where(CandidateTest.test_id == test.id)
+            .where(Candidate.identity == uuid.UUID(candidate_uuid))
+        ).first()
+        is None
     )
 
-    assert start_response.status_code == 200
-    assert start_response.json() == provision_data
+    def start() -> dict[str, Any]:
+        response = client.post(
+            f"{settings.API_V1_STR}/candidate/start_test",
+            params={"candidate_uuid": candidate_uuid},
+            json={"test_link_uuid": test_link.uuid, "device_info": "Mobile"},
+        )
+        assert response.status_code == 200
+        data: dict[str, Any] = response.json()
+        return data
+
+    # The first start creates the attempt; starting again resolves the same one.
+    first = start()
+    candidate_test = db.get(CandidateTest, first["candidate_test_id"])
+    assert candidate_test is not None
+    assert candidate_test.test_id == test.id
+    assert start() == first
 
 
 def test_external_provision_resumes_position_and_answers_cross_device(
@@ -16210,17 +16222,28 @@ def test_external_provision_resumes_position_and_answers_cross_device(
     )
     external_identifier = "375220"
 
-    # --- device A: portal launch provisions the attempt ---
-    device_a = client.post(
-        f"{settings.API_V1_STR}/candidate/external/provision",
-        json={
-            "test_link_uuid": test_link.uuid,
-            "external_identifier": external_identifier,
-        },
-        headers=token_headers,
-    )
-    assert device_a.status_code == 200
-    launch = device_a.json()
+    def portal_launch() -> dict[str, Any]:
+        """Provision the candidate, then start the test as the webapp does."""
+        provision = client.post(
+            f"{settings.API_V1_STR}/candidate/external/provision",
+            json={
+                "test_link_uuid": test_link.uuid,
+                "external_identifier": external_identifier,
+            },
+            headers=token_headers,
+        )
+        assert provision.status_code == 200
+        started = client.post(
+            f"{settings.API_V1_STR}/candidate/start_test",
+            params={"candidate_uuid": provision.json()["candidate_uuid"]},
+            json={"test_link_uuid": test_link.uuid},
+        )
+        assert started.status_code == 200
+        data: dict[str, Any] = started.json()
+        return data
+
+    # --- device A: portal launch starts the attempt ---
+    launch = portal_launch()
     candidate_test_id = launch["candidate_test_id"]
     candidate_uuid = launch["candidate_uuid"]
 
@@ -16249,16 +16272,7 @@ def test_external_provision_resumes_position_and_answers_cross_device(
     )
 
     # --- device B: same external user logs in again -> same candidate + attempt ---
-    device_b = client.post(
-        f"{settings.API_V1_STR}/candidate/external/provision",
-        json={
-            "test_link_uuid": test_link.uuid,
-            "external_identifier": external_identifier,
-        },
-        headers=token_headers,
-    )
-    assert device_b.status_code == 200
-    assert device_b.json() == launch  # same candidate_uuid + candidate_test_id reused
+    assert portal_launch() == launch  # same candidate_uuid + candidate_test_id reused
 
     # device B: resume payload carries the saved position and answers
     resume = client.get(
@@ -16315,10 +16329,17 @@ def test_external_start_reports_submitted_attempt(
         headers=token_headers,
     )
     assert provision_response.status_code == 200
-    provision_data = provision_response.json()
-    assert provision_data["is_submitted"] is False
+    candidate_uuid = provision_response.json()["candidate_uuid"]
 
-    candidate_test = db.get(CandidateTest, provision_data["candidate_test_id"])
+    started = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test",
+        params={"candidate_uuid": candidate_uuid},
+        json={"test_link_uuid": test_link.uuid, "device_info": "Portal"},
+    )
+    assert started.status_code == 200
+    assert started.json()["is_submitted"] is False
+
+    candidate_test = db.get(CandidateTest, started.json()["candidate_test_id"])
     assert candidate_test is not None
     candidate_test.is_submitted = True
     db.add(candidate_test)
@@ -16326,7 +16347,7 @@ def test_external_start_reports_submitted_attempt(
 
     start_response = client.post(
         f"{settings.API_V1_STR}/candidate/start_test",
-        params={"candidate_uuid": provision_data["candidate_uuid"]},
+        params={"candidate_uuid": candidate_uuid},
         json={
             "test_link_uuid": test_link.uuid,
             "device_info": "Mobile",
@@ -16374,29 +16395,28 @@ def test_external_provision_reuses_same_candidate_across_tests(
     )
 
     external_identifier = "375220"
-    first_response = client.post(
-        f"{settings.API_V1_STR}/candidate/external/provision",
-        json={
-            "test_link_uuid": test_a_link.uuid,
-            "external_identifier": external_identifier,
-            "device_info": "Portal",
-        },
-        headers=token_headers,
-    )
-    assert first_response.status_code == 200
-    first_data = first_response.json()
 
-    second_response = client.post(
-        f"{settings.API_V1_STR}/candidate/external/provision",
-        json={
-            "test_link_uuid": test_b_link.uuid,
-            "external_identifier": external_identifier,
-            "device_info": "Portal",
-        },
-        headers=token_headers,
-    )
-    assert second_response.status_code == 200
-    second_data = second_response.json()
+    def portal_launch(link_uuid: str) -> dict[str, Any]:
+        provision = client.post(
+            f"{settings.API_V1_STR}/candidate/external/provision",
+            json={
+                "test_link_uuid": link_uuid,
+                "external_identifier": external_identifier,
+            },
+            headers=token_headers,
+        )
+        assert provision.status_code == 200
+        started = client.post(
+            f"{settings.API_V1_STR}/candidate/start_test",
+            params={"candidate_uuid": provision.json()["candidate_uuid"]},
+            json={"test_link_uuid": link_uuid, "device_info": "Portal"},
+        )
+        assert started.status_code == 200
+        data: dict[str, Any] = started.json()
+        return data
+
+    first_data = portal_launch(test_a_link.uuid)
+    second_data = portal_launch(test_b_link.uuid)
 
     # Same recurring user -> same candidate, but a distinct attempt per test.
     assert second_data["candidate_uuid"] == first_data["candidate_uuid"]
@@ -16437,21 +16457,27 @@ def test_external_provision_is_idempotent_for_same_user_and_test(
         client=client, email=user.email, db=db
     )
 
-    body = {
-        "test_link_uuid": test_link.uuid,
-        "external_identifier": "375220",
-        "device_info": "Portal",
-    }
-    first_data = client.post(
-        f"{settings.API_V1_STR}/candidate/external/provision",
-        json=body,
-        headers=token_headers,
-    ).json()
-    second_data = client.post(
-        f"{settings.API_V1_STR}/candidate/external/provision",
-        json=body,
-        headers=token_headers,
-    ).json()
+    def portal_launch() -> dict[str, Any]:
+        provision = client.post(
+            f"{settings.API_V1_STR}/candidate/external/provision",
+            json={
+                "test_link_uuid": test_link.uuid,
+                "external_identifier": "375220",
+            },
+            headers=token_headers,
+        )
+        assert provision.status_code == 200
+        started = client.post(
+            f"{settings.API_V1_STR}/candidate/start_test",
+            params={"candidate_uuid": provision.json()["candidate_uuid"]},
+            json={"test_link_uuid": test_link.uuid, "device_info": "Portal"},
+        )
+        assert started.status_code == 200
+        data: dict[str, Any] = started.json()
+        return data
+
+    first_data = portal_launch()
+    second_data = portal_launch()
 
     assert second_data["candidate_uuid"] == first_data["candidate_uuid"]
     assert second_data["candidate_test_id"] == first_data["candidate_test_id"]
@@ -16498,7 +16524,7 @@ def test_external_provision_distinct_users_get_distinct_candidates(
     assert first_data["candidate_uuid"] != second_data["candidate_uuid"]
 
 
-def test_external_start_rejects_candidate_test_for_other_test(
+def test_external_start_gives_a_separate_attempt_per_test(
     client: TestClient, db: SessionDep
 ) -> None:
     org = Organization(name=random_lower_string())
@@ -16543,21 +16569,27 @@ def test_external_start_rejects_candidate_test_for_other_test(
         headers=token_headers,
     )
     assert provision_response.status_code == 200
-    provision_data = provision_response.json()
+    candidate_uuid = provision_response.json()["candidate_uuid"]
 
-    start_response = client.post(
-        f"{settings.API_V1_STR}/candidate/start_test",
-        params={"candidate_uuid": provision_data["candidate_uuid"]},
-        json={
-            "test_link_uuid": test_b_link.uuid,
-            "device_info": "Mobile",
-        },
-    )
+    def start(link_uuid: str) -> dict[str, Any]:
+        response = client.post(
+            f"{settings.API_V1_STR}/candidate/start_test",
+            params={"candidate_uuid": candidate_uuid},
+            json={"test_link_uuid": link_uuid, "device_info": "Mobile"},
+        )
+        assert response.status_code == 200
+        data: dict[str, Any] = response.json()
+        return data
 
-    assert start_response.status_code == 404
-    assert start_response.json()["detail"] == (
-        "Candidate test not found or invalid UUID"
-    )
+    # The candidate belongs to the organization, not to one test, so they may
+    # start another of its tests — each with its own attempt.
+    attempt_a = start(test_a_link.uuid)
+    attempt_b = start(test_b_link.uuid)
+    assert attempt_a["candidate_test_id"] != attempt_b["candidate_test_id"]
+
+    candidate_test_b = db.get(CandidateTest, attempt_b["candidate_test_id"])
+    assert candidate_test_b is not None
+    assert candidate_test_b.test_id == test_b.id
 
 
 def test_start_test_resume_requires_external_login_enabled(
@@ -16635,7 +16667,7 @@ def test_start_test_resume_unknown_candidate_uuid(
     )
 
     assert response.status_code == 404
-    assert response.json()["detail"] == "Candidate test not found or invalid UUID"
+    assert response.json()["detail"] == "Candidate not found or invalid UUID"
 
 
 def test_start_test_anonymous_allowed_when_anonymous_starts_not_blocked(


### PR DESCRIPTION
## Summary
Two related cleanups to the external-login flow merged in #513.

**1. Provision the candidate, not the attempt.** Provisioning used to create both the candidate *and* its `candidate_test` row, then hand `candidate_test_id` back in the launch URL. Since #565 made that id vestigial in the URL, this drops it: provision creates only the candidate, and `start_test?candidate_uuid=…` creates-or-resolves the attempt — exactly what the anonymous QR flow already does at the Start Test click.

Why it matters: pre-creating the attempt meant a row existed before the candidate had done anything, so "row exists" told you nothing about whether the test had been started. Aligning the two flows makes the attempt row mean *started*, which is the signal cross-device resume needs.

**2. Rename `external_user_id` → `external_identifier`.** The value is whatever identifier an org sends (canonical user id, student id, apaar id, …), not specifically a "user id".

## Changes
- **Model:** new `ExternalProvisionResponse` returning just `candidate_uuid`; `Candidate.external_identifier`, `Result.external_identifier`.
- **Model:** `ExternalProvisionRequest` no longer inherits `StartTestRequest` (@ninad-ict's review). Since provisioning only resolves the candidate, the inherited `device_info` and `form_responses` had nowhere to go — they were accepted and silently ignored. It now declares `test_link_uuid` + `external_identifier` directly; both other fields still travel with the `start_test` call that creates the attempt.
- **Route:** `provision_external_candidate_test` creates and commits only the candidate. `_get_candidate_test_by_uuid` → `_get_provisioned_candidate` (looks up the candidate by its unguessable identity, scoped to the test's organization). The `start_test` external branch find-or-creates the attempt and returns its id.
- **Migration** `b2f5a9c81d34`: renames the column `candidate.external_user_id → external_identifier` and its partial unique index `uq_candidate_org_external_user_id → uq_candidate_org_external_identifier`. Reversible; the original add-column migration is untouched.
- **Landing page knows about blocked anonymous starts** (@ninad-ict's review). An org that requires candidates to arrive from their student portal only said so when `start_test` was called — which the webapp does *after* the pre-test form, so a candidate could fill in the whole form and only then be turned away. `TestPublicLimited` now carries `blocks_anonymous_start`, and the predicate moved to `crud/organization_settings.blocks_anonymous_starts` so the public route and the `start_test` check share one definition.
- **Tests** restructured around the new two-call contract (provision, then start), plus one for the new landing flag.

One test changed meaning rather than just shape: `test_external_start_rejects_candidate_test_for_other_test` is now `test_external_start_gives_a_separate_attempt_per_test`. The old 404 was an artifact of pre-provisioning — the real boundary is organization scoping, and a candidate legitimately gets one attempt per test.

## Companions
Deploy in lockstep — the launch URL and provision payload both change shape:
- **portal-backend** `feat/sashakt-access`: sends `external_identifier`, builds the launch URL with only `candidate_uuid`, and no longer reads `candidate_test_id` from the provision response.
- **sashakt-webapp** `feat/maintain-candidate-state`: takes only `candidate_uuid` off the launch URL.

## Tested
- `pytest app/tests/api/routes/test_candidate.py` — 215 passed. (Two timezone failures in `test_create_candidate_test` / `test_update_candidate_test_by_id` are pre-existing; verified by stashing this branch's changes and re-running.)
- `bash scripts/lint.sh` — `mypy app` (127 files), `ruff check`, `ruff format --check` all clean.
- Migration up/down verified: column + index rename, reversible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External candidate provisioning now returns a candidate ID and starts or resumes attempts separately.
  * External candidates can reuse their identity across tests and devices.
  * Public test details indicate whether anonymous starts are restricted.

* **Bug Fixes**
  * Invalid candidate identities and unauthorized attempts are rejected consistently.
  * Anonymous-start behavior now follows organization access settings.

* **API Updates**
  * External candidate fields are now labeled `external_identifier`.
  * Start-test responses indicate whether an attempt was resumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->