### PR TITLE
Report is_resumed on external start

### DIFF
--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -891,35 +891,20 @@ def _get_or_create_external_candidate(
     return candidate
 
 
-def _get_or_create_candidate_test(
-    session: SessionDep,
-    *,
-    test: Test,
-    candidate: Candidate,
-    admin_id: int,
-    start_test_request: StartTestRequest,
-) -> CandidateTest:
-    """Find the candidate's existing attempt for this test, or create one.
+def _find_candidate_test(
+    session: SessionDep, *, test: Test, candidate: Candidate
+) -> CandidateTest | None:
+    """The candidate's existing attempt for this test, if any.
 
     A reused candidate may already have a CandidateTest for this test (the
     UNIQUE(test_id, candidate_id) constraint enforces one attempt per pair), so
-    re-provisioning must be idempotent rather than raising a unique violation.
+    starting again must resolve that attempt rather than raise a unique violation.
     """
-    existing = session.exec(
+    return session.exec(
         select(CandidateTest)
         .where(CandidateTest.test_id == test.id)
         .where(CandidateTest.candidate_id == candidate.id)
     ).first()
-    if existing is not None:
-        return existing
-
-    return _create_candidate_test(
-        session,
-        test=test,
-        candidate=candidate,
-        admin_id=admin_id,
-        start_test_request=start_test_request,
-    )
 
 
 def _get_external_login_value(session: SessionDep, test: Test) -> Any | None:
@@ -994,17 +979,23 @@ def start_test_for_candidate(
         _require_external_login_enabled(session, test)
         _validate_test_start_window(session, test)
         candidate = _get_provisioned_candidate(session, test, candidate_uuid)
-        candidate_test = _get_or_create_candidate_test(
-            session,
-            test=test,
-            candidate=candidate,
-            admin_id=admin_id,
-            start_test_request=start_test_request,
-        )
+        # The attempt is created on the first start, so finding one here means the
+        # candidate already started this test — on this device or another.
+        candidate_test = _find_candidate_test(session, test=test, candidate=candidate)
+        is_resumed = candidate_test is not None
+        if candidate_test is None:
+            candidate_test = _create_candidate_test(
+                session,
+                test=test,
+                candidate=candidate,
+                admin_id=admin_id,
+                start_test_request=start_test_request,
+            )
         return StartTestResponse(
             candidate_uuid=candidate_uuid,
             candidate_test_id=candidate_test.id,
             is_submitted=candidate_test.is_submitted,
+            is_resumed=is_resumed,
         )
 
     if _should_block_anonymous_start(session, test):

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -380,10 +380,7 @@ class StartTestResponse(SQLModel):
     candidate_uuid: uuid.UUID
     candidate_test_id: int
     is_submitted: bool = False
-    # True when this launch returned an already-started attempt (e.g. an external
-    # user opening the test on another device), so the client can show "Resume"
-    # and skip a pre-test form the candidate already completed.
-    is_resumed: bool = False
+    is_resumed: bool = False  # True when this launch returned an already-started attempt by an external user
 
 
 class ExternalProvisionRequest(SQLModel):

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -380,6 +380,10 @@ class StartTestResponse(SQLModel):
     candidate_uuid: uuid.UUID
     candidate_test_id: int
     is_submitted: bool = False
+    # True when this launch returned an already-started attempt (e.g. an external
+    # user opening the test on another device), so the client can show "Resume"
+    # and skip a pre-test form the candidate already completed.
+    is_resumed: bool = False
 
 
 class ExternalProvisionRequest(SQLModel):

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -16200,7 +16200,9 @@ def test_external_provision_and_start_resume_same_attempt(
     candidate_test = db.get(CandidateTest, first["candidate_test_id"])
     assert candidate_test is not None
     assert candidate_test.test_id == test.id
-    assert start() == first
+    assert first["is_resumed"] is False
+    # Launching again finds the existing attempt, which is exactly a resume.
+    assert start() == {**first, "is_resumed": True}
 
 
 def test_external_provision_resumes_position_and_answers_cross_device(
@@ -16307,7 +16309,8 @@ def test_external_provision_resumes_position_and_answers_cross_device(
     )
 
     # --- device B: same external user logs in again -> same candidate + attempt ---
-    assert portal_launch() == launch  # same candidate_uuid + candidate_test_id reused
+    # Same candidate + attempt reused, and reported as a resume this time.
+    assert portal_launch() == {**launch, "is_resumed": True}
 
     # device B: resume payload carries the saved position and answers
     resume = client.get(


### PR DESCRIPTION
> Stacked on #573 — review/merge that first. This PR is the one commit on top.

## Summary
Adds `is_resumed` to the `start_test` response so the webapp can tell a fresh start from a resume, and label the button "Resume Test" / skip the pre-test form the candidate already filled in.

With #573 in place this is almost free. Because the attempt row is now created *on the first start* rather than at provision time, finding an existing attempt **is** the resume signal — no extra query, no heuristic:

```python
candidate_test = _find_candidate_test(session, test=test, candidate=candidate)
is_resumed = candidate_test is not None
```

An earlier version of this PR needed a `_has_begun_attempt` helper that checked for a saved question position or a recorded answer, because provisioning pre-created the attempt and so "row exists" was always true. #573 removes that reason, and the helper is gone with it.

## Changes
- **Model:** `StartTestResponse.is_resumed` (defaults to `False`, so the anonymous QR flow is untouched).
- **Route:** `_get_or_create_candidate_test` → `_find_candidate_test`, with the create moved to the one call site that needs to know which of the two happened.
- **Tests:** the existing external-start and cross-device tests now assert `is_resumed` — `False` on the first start, `True` when a later launch resolves the same attempt.

## Companion
- **sashakt-webapp** sashakt-platform/sashakt-webapp#255 consumes this: the landing screen reads "Resume Test" and skips the form when `is_resumed` is true.

## Tested
- `pytest app/tests/api/routes/test_candidate.py -k "external or cross_device or resum"` — 16 passed.
- Full file — 215 passed. (`test_create_candidate_test` / `test_update_candidate_test_by_id` fail on the base too: a pre-existing IST timezone assertion, not from this change.)
- `bash scripts/lint.sh` — `mypy app` (127 files), `ruff check`, `ruff format --check` all clean.
