### PR TITLE
Make tag Visible to Candidates during Answer Review

### DIFF
--- a/backend/app/alembic/versions/ab6df88cf58b_add_show_to_candidate_to_tag_type.py
+++ b/backend/app/alembic/versions/ab6df88cf58b_add_show_to_candidate_to_tag_type.py
@@ -1,0 +1,24 @@
+"""add show_to_candidate to tag_type
+
+Revision ID: ab6df88cf58b
+Revises: d8640b20c143
+Create Date: 2026-08-13 16:17:33.052894
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ab6df88cf58b'
+down_revision = 'd8640b20c143'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('tag_type', sa.Column('show_to_candidate', sa.Boolean(), server_default='false', nullable=False))
+
+
+def downgrade():
+    op.drop_column('tag_type', 'show_to_candidate')

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -2594,6 +2594,7 @@ def get_review_feedback(
             .join(TagType, col(TagType.id) == col(Tag.tag_type_id))
             .where(
                 col(QuestionTag.question_id).in_(question_ids),
+                TagType.is_active,
                 TagType.show_to_candidate,
                 Tag.is_active,
             )

--- a/backend/app/api/routes/candidate.py
+++ b/backend/app/api/routes/candidate.py
@@ -57,6 +57,7 @@ from app.models import (
 from app.models.candidate import (
     CandidatePositionUpdateRequest,
     CandidateReviewResponse,
+    CandidateReviewTag,
     CandidateSavedAnswer,
     CandidateTimerEventType,
     CandidateTimerSyncRequest,
@@ -75,7 +76,7 @@ from app.models.question import (
     QuestionTag,
     QuestionType,
 )
-from app.models.tag import Tag
+from app.models.tag import Tag, TagType
 from app.models.test import OMRMode, TestDistrict, TestLink, TestState, TestTag
 from app.models.user import User
 from app.models.utils import CorrectAnswerType, MarkingScheme, TimeLeft
@@ -2582,6 +2583,26 @@ def get_review_feedback(
 
     revisions_by_id = {rev.id: rev for rev in question_revisions}
 
+    question_ids = {
+        rev.question_id for rev in question_revisions if rev.question_id is not None
+    }
+    tags_by_question_id: dict[int, dict[str, list[str]]] = {}
+    if question_ids:
+        tag_rows = session.exec(
+            select(QuestionTag.question_id, TagType.name, Tag.name)
+            .join(Tag, col(Tag.id) == col(QuestionTag.tag_id))
+            .join(TagType, col(TagType.id) == col(Tag.tag_type_id))
+            .where(
+                col(QuestionTag.question_id).in_(question_ids),
+                TagType.show_to_candidate,
+                Tag.is_active,
+            )
+        ).all()
+        for question_id_, tag_type_name, tag_name in tag_rows:
+            tags_by_question_id.setdefault(question_id_, {}).setdefault(
+                tag_type_name, []
+            ).append(tag_name)
+
     feedback_list: list[CandidateReviewResponse] = []
 
     for question_id in question_ids_to_fetch:
@@ -2599,6 +2620,16 @@ def get_review_feedback(
             ):
                 correct_answer = json.dumps(correct_answer)
 
+            question_tags = (
+                tags_by_question_id.get(question_revision.question_id, {})
+                if question_revision.question_id is not None
+                else {}
+            )
+            tags = [
+                CandidateReviewTag(tag_type=tag_type_name, tag=tag_names)
+                for tag_type_name, tag_names in question_tags.items()
+            ]
+
             feedback_list.append(
                 CandidateReviewResponse(
                     question_revision_id=question_id,
@@ -2607,6 +2638,7 @@ def get_review_feedback(
                     ),
                     correct_answer=correct_answer,
                     solution=question_revision.solution,
+                    tags=tags,
                 )
             )
 

--- a/backend/app/models/candidate.py
+++ b/backend/app/models/candidate.py
@@ -94,12 +94,19 @@ class CandidateSavedAnswer(SQLModel):
     correct_answer: CorrectAnswerType = None
 
 
+class CandidateReviewTag(SQLModel):
+    __test__ = False
+    tag_type: str
+    tag: list[str]
+
+
 class CandidateReviewResponse(SQLModel):
     __test__ = False
     question_revision_id: int
     submitted_answer: str | None = None
     correct_answer: CorrectAnswerType = None
     solution: str | None = None
+    tags: list[CandidateReviewTag] = []
 
 
 class CandidateTestAnswerUpdate(SQLModel):

--- a/backend/app/models/tag.py
+++ b/backend/app/models/tag.py
@@ -18,6 +18,10 @@ class TagTypeBase(SQLModel):
         default=None, nullable=True, description="Description of the Tag Type"
     )
     is_active: bool = Field(default=True)
+    show_to_candidate: bool = Field(
+        default=False,
+        description="Set true to show tags of this type to candidates during answer review",
+    )
     organization_id: int = Field(
         foreign_key="organization.id",
         nullable=False,

--- a/backend/app/tests/api/routes/test_candidate.py
+++ b/backend/app/tests/api/routes/test_candidate.py
@@ -13723,6 +13723,131 @@ def test_get_review_feedback_after_completion_with_feedback_enabled(
     assert data[0]["correct_answer"] == [1]
 
 
+def test_get_review_feedback_includes_only_public_tag_types(
+    client: TestClient, db: SessionDep
+) -> None:
+    """review-feedback exposes tags only for tag types with show_to_candidate=True."""
+    user = create_random_user(db)
+
+    org = Organization(name=random_lower_string())
+    db.add(org)
+    db.commit()
+
+    question = Question(organization_id=org.id)
+    db.add(question)
+    db.flush()
+
+    question_revision = QuestionRevision(
+        question_id=question.id,
+        created_by_id=user.id,
+        question_text=random_lower_string(),
+        question_type=QuestionType.single_choice,
+        options=[
+            {"id": 1, "key": "A", "value": "Option 1"},
+            {"id": 2, "key": "B", "value": "Option 2"},
+        ],
+        correct_answer=[1],
+    )
+    db.add(question_revision)
+    db.flush()
+
+    question.last_revision_id = question_revision.id
+    db.commit()
+    db.refresh(question_revision)
+
+    public_tag_type = TagType(
+        name="Difficulty",
+        show_to_candidate=True,
+        created_by_id=user.id,
+        organization_id=org.id,
+    )
+    private_tag_type = TagType(
+        name="Internal",
+        show_to_candidate=False,
+        created_by_id=user.id,
+        organization_id=org.id,
+    )
+    db.add(public_tag_type)
+    db.add(private_tag_type)
+    db.commit()
+
+    public_tag = Tag(
+        name="Easy",
+        tag_type_id=public_tag_type.id,
+        created_by_id=user.id,
+        organization_id=org.id,
+    )
+    private_tag = Tag(
+        name="Secret",
+        tag_type_id=private_tag_type.id,
+        created_by_id=user.id,
+        organization_id=org.id,
+    )
+    db.add(public_tag)
+    db.add(private_tag)
+    db.commit()
+
+    db.add(QuestionTag(question_id=question.id, tag_id=public_tag.id))
+    db.add(QuestionTag(question_id=question.id, tag_id=private_tag.id))
+    db.commit()
+
+    test = Test(
+        name=random_lower_string(),
+        created_by_id=user.id,
+        is_active=True,
+        link=random_lower_string(),
+        show_feedback_on_completion=True,
+    )
+    db.add(test)
+    db.commit()
+
+    test_question = TestQuestion(
+        test_id=test.id, question_revision_id=question_revision.id
+    )
+    db.add(test_question)
+    db.commit()
+
+    test_link = get_test_link(db, test_id=test.id, admin_id=test.created_by_id)
+    payload = {"test_link_uuid": test_link.uuid, "device_info": random_lower_string()}
+    start_response = client.post(
+        f"{settings.API_V1_STR}/candidate/start_test", json=payload
+    )
+    start_data = start_response.json()
+    candidate_uuid = start_data["candidate_uuid"]
+    candidate_test_id = start_data["candidate_test_id"]
+
+    answer_payload = {
+        "question_revision_id": question_revision.id,
+        "response": "[2]",
+        "visited": True,
+        "time_spent": 30,
+    }
+
+    client.post(
+        f"{settings.API_V1_STR}/candidate/submit_answer/{candidate_test_id}",
+        json=answer_payload,
+        params={"candidate_uuid": candidate_uuid},
+    )
+
+    candidate_test = db.exec(
+        select(CandidateTest).where(CandidateTest.id == candidate_test_id)
+    ).first()
+    assert candidate_test is not None
+    candidate_test.end_time = datetime.now()
+    db.add(candidate_test)
+    db.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/candidate/{candidate_test_id}/review-feedback",
+        params={"candidate_uuid": candidate_uuid},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["tags"] == [{"tag_type": "Difficulty", "tag": ["Easy"]}]
+
+
 def test_get_review_feedback_after_completion_fails_without_feedback_enabled(
     client: TestClient, db: SessionDep
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes issue: #582 

~~The PR can be rebased to Main after merger of Display Solution PR -  https://github.com/sashakt-platform/sashakt-core/pull/595~~

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Candidate answer reviews now display configured, candidate-visible tags grouped by question and tag type.
  * Tag types can be marked as visible or private during candidate review.
  * Candidate review responses now include associated visible tags.

* **Bug Fixes**
  * Ensured private tags are excluded from candidate-facing feedback.

* **Tests**
  * Added coverage verifying visible tags appear and private tags remain hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->